### PR TITLE
ci: auto-release patch on PR merge to main

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,45 @@
+name: Auto Release Patch
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  auto-release-patch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest version tag
+        id: version
+        run: |
+          LATEST=$(gh release list --repo "${{ github.repository }}" --limit 1 --json tagName --jq '.[0].tagName // "v0.0.0"')
+          echo "current=${LATEST}" >> $GITHUB_OUTPUT
+
+          MAJOR=$(echo "$LATEST" | sed 's/v//' | cut -d. -f1)
+          MINOR=$(echo "$LATEST" | sed 's/v//' | cut -d. -f2)
+          PATCH=$(echo "$LATEST" | sed 's/v//' | cut -d. -f3)
+          NEXT="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "next=${NEXT}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.next }}"
+          git push origin "${{ steps.version.outputs.next }}"
+
+      - name: Summary
+        run: |
+          echo "### Auto Release" >> $GITHUB_STEP_SUMMARY
+          echo "- Previous: \`${{ steps.version.outputs.current }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Released: \`${{ steps.version.outputs.next }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Adds a new `auto-release.yml` GitHub Actions workflow that triggers on merged PRs to `main`
- Automatically determines the next patch version from the latest GitHub release and pushes a new tag
- The existing `release.yml` workflow then picks up the tag and creates the release + updates Homebrew

Closes #16

## Test plan
- [ ] Merge this PR to `main` and verify a new patch tag is created automatically
- [ ] Verify the `Release` workflow triggers from the new tag and creates a GitHub release
- [ ] Verify no manual `make release patch` is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)