### PR TITLE
fix: use PAT for tag push so release workflow triggers

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Get latest version tag
         id: version


### PR DESCRIPTION
## Summary
- Tags pushed with the default `GITHUB_TOKEN` don't trigger other workflows (known GitHub Actions limitation)
- Uses `HOMEBREW_TAP_TOKEN` (a PAT) for checkout so `git push` authenticates with it, causing the tag push to trigger the `release.yml` workflow

Follows up on #17

## Test plan
- [ ] Merge this PR and verify the auto-release workflow pushes a tag
- [ ] Verify the `Release` workflow triggers from that tag and creates a GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)