### PR TITLE
fix: auto-release workflow tag push and version detection

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -18,10 +18,12 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
-      - name: Get latest version tag
+      - name: Get next version
         id: version
         run: |
-          LATEST=$(gh release list --repo "${{ github.repository }}" --limit 1 --json tagName --jq '.[0].tagName // "v0.0.0"')
+          git fetch --tags
+          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          LATEST="${LATEST:-v0.0.0}"
           echo "current=${LATEST}" >> $GITHUB_OUTPUT
 
           MAJOR=$(echo "$LATEST" | sed 's/v//' | cut -d. -f1)
@@ -29,13 +31,15 @@ jobs:
           PATCH=$(echo "$LATEST" | sed 's/v//' | cut -d. -f3)
           NEXT="v${MAJOR}.${MINOR}.$((PATCH + 1))"
           echo "next=${NEXT}" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and push tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git rev-parse "${{ steps.version.outputs.next }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.version.outputs.next }} already exists, skipping"
+            exit 0
+          fi
           git tag "${{ steps.version.outputs.next }}"
           git push origin "${{ steps.version.outputs.next }}"
 


### PR DESCRIPTION
## Summary
- Uses `HOMEBREW_TAP_TOKEN` (PAT) for checkout so the tag push triggers the `release.yml` workflow (tags pushed with default `GITHUB_TOKEN` don't trigger other workflows)
- Bases version bump on `git tag` instead of `gh release list` to account for orphaned tags (tag exists without a release)
- Adds a guard to skip gracefully if the computed tag already exists

Follows up on #17 / Closes #16

## Test plan
- [ ] Merge this PR and verify the auto-release workflow pushes a new tag
- [ ] Verify the `Release` workflow triggers from that tag and creates a GitHub release
- [ ] Verify Homebrew tap gets updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)