### PR TITLE
fix: prune stale worktree when directory was deleted

### DIFF
--- a/internal/integration/worktree/manager.go
+++ b/internal/integration/worktree/manager.go
@@ -37,10 +37,19 @@ func (m *worktreeManager) Create(repoDir string, branchName string) (usecase.Wor
 	if err == nil {
 		for _, wt := range existing {
 			if wt.Branch == branchName {
-				return usecase.WorktreeInfo{
-					Path:   wt.Path,
-					Branch: wt.Branch,
-				}, nil
+				// Verify the worktree directory still exists on disk.
+				if _, statErr := os.Stat(wt.Path); statErr == nil {
+					return usecase.WorktreeInfo{
+						Path:   wt.Path,
+						Branch: wt.Branch,
+					}, nil
+				}
+				// Directory was deleted — prune the stale git reference
+				// so we can create a fresh worktree below.
+				pruneCmd := exec.Command("git", "worktree", "prune")
+				pruneCmd.Dir = repoDir
+				_ = pruneCmd.Run()
+				break
 			}
 		}
 	}

--- a/internal/integration/worktree/manager_test.go
+++ b/internal/integration/worktree/manager_test.go
@@ -107,3 +107,42 @@ func TestCreate_ExistingBranchNoWorktree(t *testing.T) {
 		t.Errorf("expected branch %q, got %q", branchName, info.Branch)
 	}
 }
+
+func TestCreate_StaleWorktreePrunedAndRecreated(t *testing.T) {
+	repoDir := initTestRepo(t)
+	branchName := "stale-wt-branch"
+
+	// Create a worktree externally, then delete its directory (simulating manual rm).
+	externalPath := filepath.Join(t.TempDir(), "external-wt")
+	cmd := exec.Command("git", "worktree", "add", "-b", branchName, externalPath)
+	cmd.Dir = repoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to create external worktree: %s: %s", err, out)
+	}
+	if err := os.RemoveAll(externalPath); err != nil {
+		t.Fatalf("failed to remove worktree dir: %v", err)
+	}
+
+	// Create should detect the stale reference, prune it, and create a fresh worktree.
+	baseDir := t.TempDir()
+	mgr := &worktreeManager{baseDir: baseDir}
+	info, err := mgr.Create(repoDir, branchName)
+	if err != nil {
+		t.Fatalf("Create should prune stale worktree and recreate, got error: %v", err)
+	}
+
+	if info.Branch != branchName {
+		t.Errorf("expected branch %q, got %q", branchName, info.Branch)
+	}
+
+	// Should be in quant's default location, not the old external path.
+	expectedPath := filepath.Join(baseDir, filepath.Base(repoDir), branchName)
+	if info.Path != expectedPath {
+		t.Errorf("expected new path %q, got %q", expectedPath, info.Path)
+	}
+
+	// Verify the new worktree actually exists on disk.
+	if _, err := os.Stat(info.Path); os.IsNotExist(err) {
+		t.Error("new worktree directory was not created")
+	}
+}


### PR DESCRIPTION
## Summary
- When reusing an existing worktree, verifies the directory still exists on disk
- If the directory was manually deleted, prunes the stale git reference and creates a fresh worktree in quant's default location (`~/.quant/worktrees/`)
- Adds `TestCreate_StaleWorktreePrunedAndRecreated` test covering this edge case

Closes #14

## Test plan
- [x] `TestCreate_ReusesExistingWorktree` — reuses worktree created outside quant
- [x] `TestCreate_NewWorktree` — normal creation still works
- [x] `TestCreate_ExistingBranchNoWorktree` — checkout fallback for existing branches
- [x] `TestCreate_StaleWorktreePrunedAndRecreated` — prunes stale reference when directory was deleted, then creates fresh worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)