### PR TITLE
feat: require workspaceId on jobs, add get_current_workspace MCP tool

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -281,6 +281,9 @@ function App() {
   const prevWorkspaceId = useRef(activeWorkspaceId);
   useEffect(() => {
     localStorage.setItem("quant:activeWorkspaceId", activeWorkspaceId);
+    api.setCurrentWorkspace(activeWorkspaceId).catch((err) =>
+      console.error("failed to sync active workspace to backend:", err)
+    );
 
     // Save current tabs for the previous workspace
     if (prevWorkspaceId.current !== activeWorkspaceId) {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -408,6 +408,14 @@ export function listWorkspaces(): Promise<Workspace[]> {
   return callGo(PKG, WORKSPACE_CTRL, "ListWorkspaces");
 }
 
+export function getCurrentWorkspace(): Promise<Workspace> {
+  return callGo(PKG, WORKSPACE_CTRL, "GetCurrentWorkspace");
+}
+
+export function setCurrentWorkspace(id: string): Promise<void> {
+  return callGo(PKG, WORKSPACE_CTRL, "SetCurrentWorkspace", id);
+}
+
 export function browseClaudeConfigDir(): Promise<string> {
   return callGo(PKG, WORKSPACE_CTRL, "BrowseClaudeConfigDir");
 }

--- a/frontend/wailsjs/go/controller/workspaceController.d.ts
+++ b/frontend/wailsjs/go/controller/workspaceController.d.ts
@@ -11,6 +11,8 @@ export function CreateWorkspace(arg1:dto.CreateWorkspaceRequest):Promise<dto.Wor
 
 export function DeleteWorkspace(arg1:string):Promise<void>;
 
+export function GetCurrentWorkspace():Promise<dto.WorkspaceResponse>;
+
 export function GetWorkspace(arg1:string):Promise<dto.WorkspaceResponse>;
 
 export function ListWorkspaces():Promise<Array<dto.WorkspaceResponse>>;
@@ -18,6 +20,8 @@ export function ListWorkspaces():Promise<Array<dto.WorkspaceResponse>>;
 export function OnShutdown(arg1:context.Context):Promise<void>;
 
 export function OnStartup(arg1:context.Context):Promise<void>;
+
+export function SetCurrentWorkspace(arg1:string):Promise<void>;
 
 export function UpdateWorkspace(arg1:dto.UpdateWorkspaceRequest):Promise<dto.WorkspaceResponse>;
 

--- a/frontend/wailsjs/go/controller/workspaceController.js
+++ b/frontend/wailsjs/go/controller/workspaceController.js
@@ -18,6 +18,10 @@ export function DeleteWorkspace(arg1) {
   return window['go']['controller']['workspaceController']['DeleteWorkspace'](arg1);
 }
 
+export function GetCurrentWorkspace() {
+  return window['go']['controller']['workspaceController']['GetCurrentWorkspace']();
+}
+
 export function GetWorkspace(arg1) {
   return window['go']['controller']['workspaceController']['GetWorkspace'](arg1);
 }
@@ -32,6 +36,10 @@ export function OnShutdown(arg1) {
 
 export function OnStartup(arg1) {
   return window['go']['controller']['workspaceController']['OnStartup'](arg1);
+}
+
+export function SetCurrentWorkspace(arg1) {
+  return window['go']['controller']['workspaceController']['SetCurrentWorkspace'](arg1);
 }
 
 export function UpdateWorkspace(arg1) {

--- a/internal/application/adapter/workspace_manager.go
+++ b/internal/application/adapter/workspace_manager.go
@@ -10,4 +10,6 @@ type WorkspaceManager interface {
 	DeleteWorkspace(id string) error
 	GetWorkspace(id string) (*entity.Workspace, error)
 	ListWorkspaces() ([]entity.Workspace, error)
+	GetCurrentWorkspace() (*entity.Workspace, error)
+	SetCurrentWorkspace(id string) error
 }

--- a/internal/application/service/workspace_manager.go
+++ b/internal/application/service/workspace_manager.go
@@ -18,6 +18,7 @@ type workspaceManagerService struct {
 	saveWorkspace   usecase.SaveWorkspace
 	updateWorkspace usecase.UpdateWorkspace
 	deleteWorkspace usecase.DeleteWorkspace
+	configManager   adapter.ConfigManager
 }
 
 // NewWorkspaceManagerService creates a new workspace manager service.
@@ -26,12 +27,14 @@ func NewWorkspaceManagerService(
 	saveWorkspace usecase.SaveWorkspace,
 	updateWorkspace usecase.UpdateWorkspace,
 	deleteWorkspace usecase.DeleteWorkspace,
+	configManager adapter.ConfigManager,
 ) adapter.WorkspaceManager {
 	return &workspaceManagerService{
 		findWorkspace:   findWorkspace,
 		saveWorkspace:   saveWorkspace,
 		updateWorkspace: updateWorkspace,
 		deleteWorkspace: deleteWorkspace,
+		configManager:   configManager,
 	}
 }
 
@@ -82,4 +85,51 @@ func (s *workspaceManagerService) GetWorkspace(id string) (*entity.Workspace, er
 // ListWorkspaces retrieves all workspaces.
 func (s *workspaceManagerService) ListWorkspaces() ([]entity.Workspace, error) {
 	return s.findWorkspace.FindAllWorkspaces()
+}
+
+// GetCurrentWorkspace returns the currently active workspace.
+func (s *workspaceManagerService) GetCurrentWorkspace() (*entity.Workspace, error) {
+	cfg, err := s.configManager.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	wsID := cfg.CurrentWorkspaceID
+	if wsID == "" {
+		wsID = "default"
+	}
+
+	ws, err := s.findWorkspace.FindWorkspaceByID(wsID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find workspace: %w", err)
+	}
+	if ws == nil {
+		return nil, fmt.Errorf("current workspace not found: %s", wsID)
+	}
+
+	return ws, nil
+}
+
+// SetCurrentWorkspace sets the currently active workspace by ID.
+func (s *workspaceManagerService) SetCurrentWorkspace(id string) error {
+	// Verify workspace exists
+	ws, err := s.findWorkspace.FindWorkspaceByID(id)
+	if err != nil {
+		return fmt.Errorf("failed to find workspace: %w", err)
+	}
+	if ws == nil {
+		return fmt.Errorf("workspace not found: %s", id)
+	}
+
+	cfg, err := s.configManager.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	cfg.CurrentWorkspaceID = id
+	if err := s.configManager.SaveConfig(cfg); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	return nil
 }

--- a/internal/domain/entity/config.go
+++ b/internal/domain/entity/config.go
@@ -45,6 +45,9 @@ type Config struct {
 	ScrollbackLines int     `json:"scrollbackLines"`
 	NewLineKey      string  `json:"newLineKey"`
 
+	// Workspace
+	CurrentWorkspaceID string `json:"currentWorkspaceId"`
+
 	// Claude CLI
 	CliBinaryPath    string            `json:"cliBinaryPath"`
 	ExtraCliArgs     string            `json:"extraCliArgs"`
@@ -92,6 +95,9 @@ func NewDefaultConfig() Config {
 		CursorBlink:     true,
 		ScrollbackLines: 10000,
 		NewLineKey:      "backslash+enter",
+
+		// Workspace
+		CurrentWorkspaceID: "default",
 
 		// Claude CLI
 		CliBinaryPath:    "claude",

--- a/internal/infra/application.go
+++ b/internal/infra/application.go
@@ -107,7 +107,7 @@ func disableQuantInSettingsLocal(settingsPath string) {
 // injectQuantMCP registers the Quant MCP server so all Claude accounts can discover it.
 // 1. Adds the "quant" server entry to ~/.mcp.json (the global server registry).
 // 2. Enables it in every detected Claude config dir's settings.local.json.
-func injectQuantMCP() {
+func injectQuantMCP(port int) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return
@@ -129,7 +129,7 @@ func injectQuantMCP() {
 	}
 	mcpServers["quant"] = map[string]interface{}{
 		"type": "http",
-		"url":  "http://localhost:52945/mcp",
+		"url":  fmt.Sprintf("http://localhost:%d/mcp", port),
 	}
 	config["mcpServers"] = mcpServers
 	out, err := json.MarshalIndent(config, "", "  ")
@@ -218,14 +218,22 @@ func Run(assets embed.FS) error {
 
 	// Start MCP server for external AI tools to manage jobs.
 	mcpServer := quantmcp.NewQuantMCPServer(injector.JobManager(), injector.AgentManager(), injector.SessionManager(), injector.WorkspaceManager(), injector.RepoManager(), injector.JobGroupManager())
-	go func() {
-		if err := mcpServer.Start(); err != nil {
-			fmt.Printf("MCP server error: %v\n", err)
-		}
-	}()
+	mcpPort := mcpServer.Port()
+	fmt.Printf("[quant] MCP server on port %d → http://localhost:%d/mcp\n", mcpPort, mcpPort)
+	if mcpPort != quantmcp.DefaultPort {
+		fmt.Printf("[quant] Default port %d was busy, using %d instead\n", quantmcp.DefaultPort, mcpPort)
+	}
+	if err := mcpServer.Start(); err != nil {
+		fmt.Printf("MCP server error: %v\n", err)
+	}
 
 	// Inject Quant MCP into Claude settings so sessions auto-discover it.
-	injectQuantMCP()
+	// Skip injection when QUANT_SKIP_MCP_INJECT=1 (e.g. running a second instance for testing).
+	if os.Getenv("QUANT_SKIP_MCP_INJECT") != "1" {
+		injectQuantMCP(mcpPort)
+	} else {
+		fmt.Println("[quant] Skipping MCP injection (QUANT_SKIP_MCP_INJECT=1)")
+	}
 
 	// Start job scheduler for recurring/one-time scheduled jobs.
 	jobScheduler := injector.JobScheduler()
@@ -263,7 +271,9 @@ func Run(assets embed.FS) error {
 			jobGroupCtrl.OnShutdown(ctx)
 			jobScheduler.Stop()
 			_ = mcpServer.Stop()
-			removeQuantMCP()
+			if os.Getenv("QUANT_SKIP_MCP_INJECT") != "1" {
+				removeQuantMCP()
+			}
 		},
 		Bind: []interface{}{
 			sessionCtrl,

--- a/internal/infra/dependency/injector.go
+++ b/internal/infra/dependency/injector.go
@@ -297,10 +297,11 @@ func (i *Injector) WorkspaceManager() appAdapter.WorkspaceManager {
 	if i.workspaceManager == nil {
 		wp := i.WorkspacePersistence()
 		i.workspaceManager = service.NewWorkspaceManagerService(
-			wp, // FindWorkspace
-			wp, // SaveWorkspace
-			wp, // UpdateWorkspace
-			wp, // DeleteWorkspace
+			wp,                 // FindWorkspace
+			wp,                 // SaveWorkspace
+			wp,                 // UpdateWorkspace
+			wp,                 // DeleteWorkspace
+			i.ConfigManager(),  // ConfigManager
 		)
 	}
 	return i.workspaceManager

--- a/internal/integration/adapter/workspace_controller.go
+++ b/internal/integration/adapter/workspace_controller.go
@@ -16,6 +16,8 @@ type WorkspaceController interface {
 	DeleteWorkspace(id string) error
 	GetWorkspace(id string) (*dto.WorkspaceResponse, error)
 	ListWorkspaces() ([]dto.WorkspaceResponse, error)
+	GetCurrentWorkspace() (*dto.WorkspaceResponse, error)
+	SetCurrentWorkspace(id string) error
 	BrowseClaudeConfigDir() (string, error)
 	BrowseMcpConfigFile() (string, error)
 	ValidatePaths(claudeRoot string, mcpRoot string) dto.PathValidationResult

--- a/internal/integration/entrypoint/controller/workspace.go
+++ b/internal/integration/entrypoint/controller/workspace.go
@@ -91,6 +91,21 @@ func (c *workspaceController) ListWorkspaces() ([]dto.WorkspaceResponse, error) 
 	return dto.WorkspaceResponseListFromEntities(workspaces), nil
 }
 
+// GetCurrentWorkspace returns the currently active workspace.
+func (c *workspaceController) GetCurrentWorkspace() (*dto.WorkspaceResponse, error) {
+	workspace, err := c.workspaceManager.GetCurrentWorkspace()
+	if err != nil {
+		return nil, err
+	}
+
+	return dto.WorkspaceResponseFromEntityPtr(workspace), nil
+}
+
+// SetCurrentWorkspace sets the currently active workspace by ID.
+func (c *workspaceController) SetCurrentWorkspace(id string) error {
+	return c.workspaceManager.SetCurrentWorkspace(id)
+}
+
 // BrowseClaudeConfigDir opens a native directory picker for selecting a .claude config directory.
 func (c *workspaceController) BrowseClaudeConfigDir() (string, error) {
 	path, err := wailsRuntime.OpenDirectoryDialog(c.ctx, wailsRuntime.OpenDialogOptions{

--- a/internal/integration/mcp/server.go
+++ b/internal/integration/mcp/server.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -19,6 +20,9 @@ import (
 	"quant/internal/domain/entity"
 )
 
+// DefaultPort is the preferred MCP server port.
+const DefaultPort = 52945
+
 // QuantMCPServer wraps an MCP server that exposes job, agent, session, workspace, and repo management tools.
 type QuantMCPServer struct {
 	jobManager       appAdapter.JobManager
@@ -28,9 +32,12 @@ type QuantMCPServer struct {
 	repoManager      appAdapter.RepoManager
 	jobGroupManager  appAdapter.JobGroupManager
 	httpServer       *http.Server
+	listener         net.Listener
+	port             int
 }
 
 // NewQuantMCPServer creates a new MCP server with all management tools registered.
+// It tries the default port first, then probes up to 10 consecutive ports to find one that's free.
 func NewQuantMCPServer(jobManager appAdapter.JobManager, agentManager appAdapter.AgentManager, sessionManager appAdapter.SessionManager, workspaceManager appAdapter.WorkspaceManager, repoManager appAdapter.RepoManager, jobGroupManager appAdapter.JobGroupManager) *QuantMCPServer {
 	mcpServer := server.NewMCPServer("quant", "1.0.0")
 
@@ -50,17 +57,46 @@ func NewQuantMCPServer(jobManager appAdapter.JobManager, agentManager appAdapter
 	mux := http.NewServeMux()
 	mux.Handle("/mcp", streamable)
 
+	// Find an available port starting from the default.
+	var listener net.Listener
+	var port int
+	for p := DefaultPort; p < DefaultPort+10; p++ {
+		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", p))
+		if err == nil {
+			listener = ln
+			port = p
+			break
+		}
+	}
+	if listener == nil {
+		// Fallback: let the OS pick any available port.
+		ln, err := net.Listen("tcp", ":0")
+		if err == nil {
+			listener = ln
+			port = ln.Addr().(*net.TCPAddr).Port
+		}
+	}
+
+	s.listener = listener
+	s.port = port
 	s.httpServer = &http.Server{
-		Addr:    ":52945",
 		Handler: mux,
 	}
 
 	return s
 }
 
-// Start begins listening for MCP requests in a background goroutine.
+// Port returns the actual port the MCP server is bound to.
+func (s *QuantMCPServer) Port() int {
+	return s.port
+}
+
+// Start begins serving MCP requests on the pre-bound listener.
 func (s *QuantMCPServer) Start() error {
-	go s.httpServer.ListenAndServe()
+	if s.listener == nil {
+		return fmt.Errorf("no listener available — could not bind to any port")
+	}
+	go s.httpServer.Serve(s.listener)
 	return nil
 }
 
@@ -120,6 +156,7 @@ Returns the created job object with the generated ID. Use this ID for run_job, u
 			mcp.WithString("name", mcp.Required(), mcp.Description("Unique job name (e.g. health-check, deploy-staging, code-review-bot). Shown on canvas nodes")),
 			mcp.WithString("description", mcp.Description("What the job does — shown in the canvas UI tooltip and job details")),
 			mcp.WithString("type", mcp.Required(), mcp.Description("'claude' for Claude CLI sessions, 'bash' for shell scripts")),
+			mcp.WithString("workspaceId", mcp.Required(), mcp.Description("Workspace ID where this job will be created. Use get_current_workspace to retrieve the active workspace ID")),
 			mcp.WithString("workingDirectory", mcp.Description("Working directory (supports ~/path). Leave empty for home dir. This is where Claude or the script runs")),
 			// Schedule
 			mcp.WithBoolean("scheduleEnabled", mcp.Description("Enable scheduled execution. False = manual/trigger only. Default: false")),
@@ -170,6 +207,7 @@ Common workflows:
 - Add env vars: update_job(id, envVariables='{"KEY":"value"}')
 - Disable bypass: update_job(id, allowBypass=false)`),
 			mcp.WithString("id", mcp.Required(), mcp.Description("Job ID to update (get from list_jobs)")),
+			mcp.WithString("workspaceId", mcp.Description("Workspace ID. Use get_current_workspace to retrieve the active workspace ID")),
 			mcp.WithString("name", mcp.Description("Job name")),
 			mcp.WithString("description", mcp.Description("Job description")),
 			mcp.WithString("type", mcp.Description("'claude' or 'bash'")),
@@ -667,6 +705,21 @@ Returns the created session object with generated ID. The session starts in 'idl
 	// -----------------------------------------------------------------------
 
 	mcpServer.AddTool(
+		mcp.NewTool("get_current_workspace",
+			mcp.WithDescription(`Returns the currently active workspace ID and name. Use this to get the workspaceId before creating or managing jobs.`),
+		),
+		s.handleGetCurrentWorkspace,
+	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("set_current_workspace",
+			mcp.WithDescription(`Set the currently active workspace. This persists the selection so get_current_workspace returns the correct workspace.`),
+			mcp.WithString("id", mcp.Required(), mcp.Description("Workspace ID to set as current (get from list_workspaces)")),
+		),
+		s.handleSetCurrentWorkspace,
+	)
+
+	mcpServer.AddTool(
 		mcp.NewTool("list_workspaces",
 			mcp.WithDescription(`List all workspaces. Returns an array of workspace objects with id, name, and timestamps. Workspaces are visual groupings for organizing sessions, jobs, and agents.`),
 		),
@@ -876,10 +929,16 @@ func (s *QuantMCPServer) handleGetJob(_ context.Context, request mcp.CallToolReq
 func (s *QuantMCPServer) handleCreateJob(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
 
+	workspaceID, err := requiredString(request, "workspaceId")
+	if err != nil {
+		return mcp.NewToolResultError("workspaceId is required — use get_current_workspace to retrieve it"), nil
+	}
+
 	job := entity.Job{
 		Name:                stringArg(args, "name"),
 		Description:         stringArg(args, "description"),
 		Type:                stringArg(args, "type"),
+		WorkspaceID:         workspaceID,
 		WorkingDirectory:    stringArg(args, "workingDirectory"),
 		ScheduleEnabled:     boolArg(args, "scheduleEnabled"),
 		ScheduleType:        stringArg(args, "scheduleType"),
@@ -936,6 +995,9 @@ func (s *QuantMCPServer) handleUpdateJob(_ context.Context, request mcp.CallTool
 	}
 
 	// Merge provided fields onto existing job.
+	if v, ok := args["workspaceId"]; ok {
+		existing.WorkspaceID, _ = v.(string)
+	}
 	if v, ok := args["name"]; ok {
 		existing.Name = v.(string)
 	}
@@ -1836,6 +1898,33 @@ func (s *QuantMCPServer) handleRenameSession(_ context.Context, request mcp.Call
 // Workspace handlers
 // ---------------------------------------------------------------------------
 
+func (s *QuantMCPServer) handleGetCurrentWorkspace(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	workspace, err := s.workspaceManager.GetCurrentWorkspace()
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	return marshalResult(workspaceToMap(workspace))
+}
+
+func (s *QuantMCPServer) handleSetCurrentWorkspace(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	id, err := requiredString(request, "id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	if err := s.workspaceManager.SetCurrentWorkspace(id); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	workspace, err := s.workspaceManager.GetWorkspace(id)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	return marshalResult(workspaceToMap(workspace))
+}
+
 func (s *QuantMCPServer) handleListWorkspaces(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	workspaces, err := s.workspaceManager.ListWorkspaces()
 	if err != nil {
@@ -2278,6 +2367,7 @@ func jobToMap(job *entity.Job) map[string]any {
 		"name":                job.Name,
 		"description":         job.Description,
 		"type":                job.Type,
+		"workspaceId":         job.WorkspaceID,
 		"workingDirectory":    job.WorkingDirectory,
 		"scheduleEnabled":     job.ScheduleEnabled,
 		"scheduleType":        job.ScheduleType,


### PR DESCRIPTION
## Summary

- **`create_job` now requires `workspaceId`** — fails with a clear error pointing to `get_current_workspace` when missing
- **New MCP tools**: `get_current_workspace` and `set_current_workspace` for workspace context awareness
- **`update_job`** accepts optional `workspaceId` for workspace reassignment
- **`jobToMap`** now includes `workspaceId` in all job responses (was missing)
- **Dynamic MCP port selection** — auto-picks next free port when default (52945) is busy, prints it to console
- **Frontend sync** — workspace changes in the UI are persisted to backend config

## Test plan

- [x] `get_current_workspace` returns `{id: "default", name: "Default"}`
- [x] `create_job` without `workspaceId` returns error with guidance
- [x] `create_job` with `workspaceId` creates job in correct workspace
- [x] `set_current_workspace` with valid ID succeeds
- [x] `set_current_workspace` with invalid ID returns error
- [x] `update_job` preserves/updates `workspaceId`
- [x] `list_jobs` includes `workspaceId` in response
- [x] Main quant instance (port 52945) unaffected by second instance on 52946
- [x] Second instance auto-detects busy port and prints new port to console

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)