### PR TITLE
fix: restore canvas positions and minimap on workspace switch

### DIFF
--- a/frontend/src/components/JobsView.tsx
+++ b/frontend/src/components/JobsView.tsx
@@ -559,7 +559,6 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
   }, [openDropdownGroup]);
 
   const canvasRef = useRef<HTMLDivElement>(null);
-  const initializedRef = useRef(false);
 
   const selectedJob = jobs.find((j) => j.id === selectedJobId) ?? null;
   const selectedRun = runs.find((r) => r.id === selectedRunId) ?? null;
@@ -684,12 +683,17 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
     return map;
   }, [jobs]);
 
-  // Initialize node positions on first render with jobs
+  // Clear stale positions immediately on workspace switch so minimap doesn't vanish
   useEffect(() => {
-    if (initializedRef.current) return;
-    if (jobs.length === 0) return;
-    initializedRef.current = true;
+    setNodePositions({});
+  }, [activeWorkspaceId]);
 
+  // Initialize node positions whenever jobs or workspace changes
+  useEffect(() => {
+    if (jobs.length === 0) {
+      setNodePositions({});
+      return;
+    }
     const saved = loadPositions(activeWorkspaceId);
     const hasAllPositions = jobs.every((j) => saved[j.id]);
     if (hasAllPositions) {
@@ -699,7 +703,7 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
       setNodePositions(layout);
       savePositions(layout, activeWorkspaceId);
     }
-  }, [jobs]);
+  }, [jobs, activeWorkspaceId]);
 
   // When modal opens, set selectedJobId for tab rendering and fetch runs
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixes Jobs canvas nodes stacking at (0,0) and minimap vanishing when switching workspaces
- Merged two separate effects into one with `[jobs, activeWorkspaceId]` deps, removing `initializedRef` that prevented re-initialization
- Added immediate position-clear effect on workspace switch to prevent stale job IDs from breaking the minimap

Closes #5

## Test plan
- [ ] Run `wails dev`, create jobs in two workspaces with different positions
- [ ] Switch from workspace A to B — verify nodes load at saved positions (not stacked at 0,0)
- [ ] Switch back to A — verify positions are restored exactly
- [ ] Verify minimap remains visible after each switch
- [ ] Click "auto-layout" in a workspace, switch away and back — verify auto-layout positions persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)