### PR TITLE
feat: run_job_with_context MCP tool

### DIFF
--- a/internal/application/adapter/job_manager.go
+++ b/internal/application/adapter/job_manager.go
@@ -13,6 +13,7 @@ type JobManager interface {
 	ListJobs() ([]entity.Job, error)
 	GetTriggersForJob(jobID string) (onSuccess []entity.JobTrigger, onFailure []entity.JobTrigger, triggeredBy []entity.JobTrigger, err error)
 	RunJob(jobID string, triggeredByRunID string, correlationID ...string) (*entity.JobRun, error)
+	RunJobWithContext(jobID string, context string) (*entity.JobRun, error)
 	RerunJob(jobID string, originalRunID string) (*entity.JobRun, error)
 	CancelRun(runID string) error
 	GetRun(runID string) (*entity.JobRun, error)

--- a/internal/application/service/job_manager.go
+++ b/internal/application/service/job_manager.go
@@ -234,6 +234,24 @@ func (s *jobManagerService) RunJob(jobID string, triggeredByRunID string, correl
 	return &run, nil
 }
 
+// RunJobWithContext starts a new run for a job, injecting arbitrary context into its prompt.
+// The context string is prepended to the job's prompt in the same format as trigger context,
+// so existing jobs that parse TASK_IDENTIFIER= etc. work without modification.
+func (s *jobManagerService) RunJobWithContext(jobID string, context string) (*entity.JobRun, error) {
+	run, err := s.RunJob(jobID, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if context != "" {
+		s.mu.Lock()
+		s.triggerCtx[run.ID] = context
+		s.mu.Unlock()
+	}
+
+	return run, nil
+}
+
 // RerunJob creates a new run for a job, preserving the trigger context from a previous run.
 // It looks up the original run's triggeredBy parent and rebuilds the same context injection.
 func (s *jobManagerService) RerunJob(jobID string, originalRunID string) (*entity.JobRun, error) {

--- a/internal/integration/mcp/server.go
+++ b/internal/integration/mcp/server.go
@@ -275,7 +275,24 @@ The Quant canvas UI shows running jobs with a pulsing green border and highlight
 		s.handleRunJob,
 	)
 
-	// 6b. rerun_job
+	// 6b. run_job_with_context
+	mcpServer.AddTool(
+		mcp.NewTool("run_job_with_context",
+			mcp.WithDescription(`Start a job immediately, injecting arbitrary context into its prompt — same as run_job but with a context payload that gets prepended to the job's trigger context.
+
+Use this to start a pipeline at any step without depending on a previous run existing. The context string is injected as-is into the job's prompt, so use the same format as upstream job output (e.g. TASK_IDENTIFIER=PLT-1032\nREPO_FOLDERS=wallet-api.worktree.PLT-1032).
+
+Useful for:
+- Retrying a specific stage after fixing a job prompt
+- Starting mid-pipeline for testing a new job
+- Recovering a broken pipeline without re-running expensive upstream jobs`),
+			mcp.WithString("id", mcp.Required(), mcp.Description("Job ID to run (get from list_jobs)")),
+			mcp.WithString("context", mcp.Required(), mcp.Description("Freeform string injected as trigger context into the job's prompt")),
+		),
+		s.handleRunJobWithContext,
+	)
+
+	// 6c. rerun_job
 	mcpServer.AddTool(
 		mcp.NewTool("rerun_job",
 			mcp.WithDescription(`Rerun a job preserving the trigger context from a previous run.
@@ -1116,6 +1133,25 @@ func (s *QuantMCPServer) handleRunJob(_ context.Context, request mcp.CallToolReq
 	}
 
 	run, err := s.jobManager.RunJob(id, "")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	return marshalResult(runToMap(run))
+}
+
+func (s *QuantMCPServer) handleRunJobWithContext(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	id, err := requiredString(request, "id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	ctx, err := requiredString(request, "context")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	run, err := s.jobManager.RunJobWithContext(id, ctx)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}


### PR DESCRIPTION
## Summary
- Adds `run_job_with_context` MCP tool that starts a job with injected arbitrary trigger context
- Allows AI agents to start pipelines at any step without depending on a previous run
- Uses the same `triggerCtx` injection mechanism as `RerunJob`/`ResumeJob`/`AdvancePipeline`

Closes #6

## Test plan
- [x] Tool registered and visible in `tools/list`
- [x] Happy path: job starts with context injected into `InjectedContext` field
- [x] Error handling: missing params return proper error messages
- [x] No side effects: `triggeredBy` empty, fresh `correlationId`, clean cancellation

Full test report: https://github.com/brienze1/quant/issues/6#issuecomment-4227160964

🤖 Generated with [Claude Code](https://claude.com/claude-code)