### PR TITLE
fix: triage prompt textarea always appears focused

### DIFF
--- a/frontend/src/components/CreateJobModal.tsx
+++ b/frontend/src/components/CreateJobModal.tsx
@@ -655,9 +655,9 @@ export function CreateJobModal({ jobs, agents, editJob, onSubmit, onCancel }: Pr
                     maxLength={500}
                     value={form.triagePrompt}
                     onChange={(e) => update("triagePrompt", e.target.value)}
-                    style={{ ...inputStyle, width: "100%", height: 56, resize: "none", padding: "8px 12px", boxSizing: "border-box" as const, borderColor: form.triagePrompt ? "var(--q-cyan)" : "var(--q-border)" }}
+                    style={{ ...inputStyle, width: "100%", height: 56, resize: "none", padding: "8px 12px", boxSizing: "border-box" as const }}
                     onFocus={(e) => (e.currentTarget.style.borderColor = "var(--q-accent)")}
-                    onBlur={(e) => (e.currentTarget.style.borderColor = form.triagePrompt ? "var(--q-cyan)" : "var(--q-border)")}
+                    onBlur={(e) => (e.currentTarget.style.borderColor = "var(--q-border)")}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Removed conditional cyan `borderColor` from triage prompt textarea that made it look permanently selected when it contained text
- The `onBlur` handler now always resets to the default border color instead of conditionally keeping cyan

Closes #7

## Test plan
- [x] Textarea with no text, unfocused — shows default border
- [x] Textarea with no text, focused — shows accent border
- [x] Textarea with text, focused — shows accent border
- [x] Textarea with text, blurred — shows default border (was cyan before fix)

All states verified via Playwright MCP browser automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)