### PR TITLE
feat: custom conditional triggers with per-trigger evaluation prompts

### DIFF
--- a/frontend/src/components/CreateJobModal.tsx
+++ b/frontend/src/components/CreateJobModal.tsx
@@ -44,6 +44,7 @@ function buildDefaultForm(): CreateJobRequest {
     envVariables: {},
     onSuccess: [],
     onFailure: [],
+    onCustom: [],
   };
 }
 
@@ -75,6 +76,7 @@ function jobToForm(job: Job): CreateJobRequest {
     envVariables: job.envVariables ?? {},
     onSuccess: job.onSuccess ?? [],
     onFailure: job.onFailure ?? [],
+    onCustom: job.onCustom ?? [],
   };
 }
 

--- a/frontend/src/components/JobsView.tsx
+++ b/frontend/src/components/JobsView.tsx
@@ -377,7 +377,9 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
   const [panning, setPanning] = useState<{ startX: number; startY: number; offsetStartX: number; offsetStartY: number } | null>(null);
   const [canvasModalJobId, setCanvasModalJobId] = useState<string | null>(null);
   const [canvasModalTab, setCanvasModalTab] = useState<JobTab>("settings");
-  const [connectingMode, setConnectingMode] = useState<{ type: "success" | "failure"; sourceId?: string } | null>(null);
+  const [connectingMode, setConnectingMode] = useState<{ type: "success" | "failure" | "custom"; sourceId?: string } | null>(null);
+  const [customPromptModal, setCustomPromptModal] = useState<{ sourceId: string; targetId: string } | null>(null);
+  const [customPromptInput, setCustomPromptInput] = useState("");
   const [triggerDropdownOpen, setTriggerDropdownOpen] = useState(false);
   const [groupsSidebarWidth, setGroupsSidebarWidth] = useState(() => {
     try { return parseInt(localStorage.getItem("quant-groups-sidebar-width") || "200", 10); } catch { return 200; }
@@ -565,7 +567,7 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
   const [pipelineRuns, setPipelineRuns] = useState<JobRun[]>([]);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [runningJobIds, setRunningJobIds] = useState<Set<string>>(new Set());
-  const [selectedEdge, setSelectedEdge] = useState<{ sourceId: string; targetId: string; type: "success" | "failure" } | null>(null);
+  const [selectedEdge, setSelectedEdge] = useState<{ sourceId: string; targetId: string; type: "success" | "failure" | "custom" } | null>(null);
   const [edgeDeleteHover, setEdgeDeleteHover] = useState(false);
   const [wavePhase, setWavePhase] = useState(0);
   const waveAmplitude = useRef(0);
@@ -1029,6 +1031,9 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
             onFailure: edge.type === "failure"
               ? sourceJob.onFailure.filter((id) => id !== edge.targetId)
               : sourceJob.onFailure,
+            onCustom: edge.type === "custom"
+              ? (sourceJob.onCustom ?? []).filter((ct) => ct.targetJobId !== edge.targetId)
+              : (sourceJob.onCustom ?? []),
           }).then(() => {
             setSelectedEdge(null);
             onRefreshJobs();
@@ -1202,16 +1207,23 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
       workspaceId: sourceJob.workspaceId,
       onSuccess: [...sourceJob.onSuccess],
       onFailure: [...sourceJob.onFailure],
+      onCustom: [...(sourceJob.onCustom ?? [])],
     };
 
     if (connectingMode.type === "success") {
       if (!updateReq.onSuccess.includes(jobId)) {
         updateReq.onSuccess.push(jobId);
       }
-    } else {
+    } else if (connectingMode.type === "failure") {
       if (!updateReq.onFailure.includes(jobId)) {
         updateReq.onFailure.push(jobId);
       }
+    } else if (connectingMode.type === "custom") {
+      // Show custom prompt modal instead of creating immediately
+      setCustomPromptModal({ sourceId: connectingMode.sourceId!, targetId: jobId });
+      setCustomPromptInput("");
+      setConnectingMode(null);
+      return;
     }
 
     try {
@@ -1221,6 +1233,53 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
       console.error("failed to create connection:", err);
     }
     setConnectingMode(null);
+  }
+
+  async function handleCustomPromptSubmit() {
+    if (!customPromptModal) return;
+    const sourceJob = jobs.find((j) => j.id === customPromptModal.sourceId);
+    if (!sourceJob) return;
+
+    const updateReq: UpdateJobRequest = {
+      id: sourceJob.id,
+      name: sourceJob.name,
+      description: sourceJob.description,
+      type: sourceJob.type,
+      workingDirectory: sourceJob.workingDirectory,
+      scheduleEnabled: sourceJob.scheduleEnabled,
+      scheduleType: sourceJob.scheduleType,
+      cronExpression: sourceJob.cronExpression,
+      scheduleInterval: sourceJob.scheduleInterval,
+      timeoutSeconds: sourceJob.timeoutSeconds,
+      prompt: sourceJob.prompt,
+      allowBypass: sourceJob.allowBypass,
+      autonomousMode: sourceJob.autonomousMode,
+      maxRetries: sourceJob.maxRetries,
+      model: sourceJob.model,
+      overrideRepoCommand: sourceJob.overrideRepoCommand,
+      claudeCommand: sourceJob.claudeCommand,
+      agentId: sourceJob.agentId,
+      successPrompt: sourceJob.successPrompt,
+      failurePrompt: sourceJob.failurePrompt,
+      metadataPrompt: sourceJob.metadataPrompt,
+      triagePrompt: sourceJob.triagePrompt ?? "",
+      interpreter: sourceJob.interpreter,
+      scriptContent: sourceJob.scriptContent,
+      envVariables: sourceJob.envVariables,
+      workspaceId: sourceJob.workspaceId,
+      onSuccess: [...sourceJob.onSuccess],
+      onFailure: [...sourceJob.onFailure],
+      onCustom: [...(sourceJob.onCustom ?? []), { targetJobId: customPromptModal.targetId, customPrompt: customPromptInput }],
+    };
+
+    try {
+      await api.updateJob(updateReq);
+      onRefreshJobs();
+    } catch (err) {
+      console.error("failed to create custom connection:", err);
+    }
+    setCustomPromptModal(null);
+    setCustomPromptInput("");
   }
 
   function handleAutoLayout() {
@@ -1456,6 +1515,12 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
         {renderSection("triggers", <>
           {renderKeyValue("on_success", selectedJob.onSuccess)}
           {renderKeyValue("on_failure", selectedJob.onFailure)}
+          {renderKeyValue("on_custom", (selectedJob.onCustom ?? []).length > 0
+            ? (selectedJob.onCustom ?? []).map((ct) => {
+                const j = jobs.find((jj) => jj.id === ct.targetJobId);
+                return `${j?.name ?? ct.targetJobId.slice(0, 8)}: "${ct.customPrompt}"`;
+              }).join("; ")
+            : "")}
           {renderKeyValue("triggered_by", selectedJob.triggeredBy.length > 0
             ? selectedJob.triggeredBy.map((ref) => {
                 const j = jobs.find((jj) => jj.id === ref.jobId);
@@ -1935,11 +2000,11 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
       const sourcePos = nodePositions[job.id];
       if (!sourcePos) continue;
 
-      const drawEdge = (targetId: string, edgeType: "success" | "failure") => {
+      const drawEdge = (targetId: string, edgeType: "success" | "failure" | "custom", customPrompt?: string) => {
         const targetPos = nodePositions[targetId];
         if (!targetPos) return;
 
-        const edgeColor = edgeType === "success" ? "var(--q-accent)" : "var(--q-error)";
+        const edgeColor = edgeType === "success" ? "var(--q-accent)" : edgeType === "custom" ? "#3B82F6" : "var(--q-error)";
         const k = keyIdx++;
         const isSelected = selectedEdge?.sourceId === job.id && selectedEdge?.targetId === targetId && selectedEdge?.type === edgeType;
         const isFlashing = flashingEdges.has(`${job.id}->${targetId}`);
@@ -2120,6 +2185,9 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
                       onFailure: edgeType === "failure"
                         ? sourceJob.onFailure.filter((id) => id !== targetId)
                         : sourceJob.onFailure,
+                      onCustom: edgeType === "custom"
+                        ? (sourceJob.onCustom ?? []).filter((ct) => ct.targetJobId !== targetId)
+                        : (sourceJob.onCustom ?? []),
                     });
                     setSelectedEdge(null);
                     setEdgeDeleteHover(false);
@@ -2143,6 +2211,9 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
       }
       for (const targetId of (job.onFailure ?? [])) {
         drawEdge(targetId, "failure");
+      }
+      for (const ct of (job.onCustom ?? [])) {
+        drawEdge(ct.targetJobId, "custom", ct.customPrompt);
       }
     }
 
@@ -2474,6 +2545,7 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
           <defs>
             <marker id="arrow-success" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="var(--q-accent)"/></marker>
             <marker id="arrow-failure" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="var(--q-error)"/></marker>
+            <marker id="arrow-custom" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#3B82F6"/></marker>
             <marker id="arrow-selected" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="var(--q-fg)"/></marker>
             <marker id="arrow-delete" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="var(--q-error)"/></marker>
             <marker id="arrow-dim" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="var(--q-fg-muted)"/></marker>
@@ -2522,8 +2594,8 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
               const pCpLen = Math.min(Math.max(pDist * 0.35, 40), 120);
               const sNx = sx - (srcPos.x + NODE_W / 2), sNy = sy - (srcPos.y + NODE_H / 2);
               const sNLen = Math.sqrt(sNx * sNx + sNy * sNy) || 1;
-              const color = connectingMode.type === "success" ? "var(--q-accent)" : "var(--q-error)";
-              const arrowId = connectingMode.type === "success" ? "arrow-success" : "arrow-failure";
+              const color = connectingMode.type === "success" ? "var(--q-accent)" : connectingMode.type === "custom" ? "#3B82F6" : "var(--q-error)";
+              const arrowId = connectingMode.type === "success" ? "arrow-success" : connectingMode.type === "custom" ? "arrow-custom" : "arrow-failure";
               return (
                 <path
                   d={`M ${sx},${sy} C ${sx + (sNx / sNLen) * pCpLen},${sy + (sNy / sNLen) * pCpLen} ${tx},${ty} ${tx},${ty}`}
@@ -3237,6 +3309,30 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
                   on failure
                   {connectingMode?.type === "failure" && (
                     <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="var(--q-error)" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" style={{ marginLeft: "auto" }}>
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                  )}
+                </button>
+                <button
+                  onClick={() => {
+                    setConnectingMode(connectingMode?.type === "custom" ? null : { type: "custom" });
+                    setTriggerDropdownOpen(false);
+                  }}
+                  style={{
+                    display: "flex", alignItems: "center", gap: 6,
+                    width: "100%", padding: "6px 12px",
+                    background: connectingMode?.type === "custom" ? "var(--q-border)" : "none",
+                    border: "none", cursor: "pointer",
+                    color: "#3B82F6", textAlign: "left", fontSize: 11,
+                    fontFamily: font,
+                  }}
+                  onMouseEnter={(e) => { if (connectingMode?.type !== "custom") e.currentTarget.style.backgroundColor = "var(--q-bg-inset)"; }}
+                  onMouseLeave={(e) => { if (connectingMode?.type !== "custom") e.currentTarget.style.backgroundColor = "transparent"; }}
+                >
+                  <span style={{ width: 6, height: 6, borderRadius: "50%", backgroundColor: "#3B82F6", flexShrink: 0 }} />
+                  on custom
+                  {connectingMode?.type === "custom" && (
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#3B82F6" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" style={{ marginLeft: "auto" }}>
                       <polyline points="20 6 9 17 4 12" />
                     </svg>
                   )}
@@ -4004,6 +4100,68 @@ export function JobsView({ jobs, agents, jobGroups, activeWorkspaceId, onCreateJ
           </div>
         );
       })()}
+      {/* Custom prompt modal for creating custom trigger edges */}
+      {customPromptModal && (
+        <div style={{
+          position: "fixed", inset: 0, zIndex: 99999,
+          display: "flex", alignItems: "center", justifyContent: "center",
+          backgroundColor: "rgba(0,0,0,0.5)",
+        }} onClick={() => { setCustomPromptModal(null); setCustomPromptInput(""); }}>
+          <div style={{
+            backgroundColor: "var(--q-bg-surface)",
+            border: "1px solid var(--q-border)",
+            borderRadius: 8, padding: 20, minWidth: 380, maxWidth: 480,
+            fontFamily: font, boxShadow: "0 8px 24px rgba(0,0,0,0.5)",
+          }} onClick={(e) => e.stopPropagation()}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: "#3B82F6", marginBottom: 12 }}>
+              custom trigger prompt
+            </div>
+            <div style={{ fontSize: 10, color: "var(--q-fg-secondary)", marginBottom: 8 }}>
+              {(() => {
+                const src = jobs.find((j) => j.id === customPromptModal.sourceId);
+                const tgt = jobs.find((j) => j.id === customPromptModal.targetId);
+                return `${src?.name ?? "source"} → ${tgt?.name ?? "target"}`;
+              })()}
+            </div>
+            <textarea
+              autoFocus
+              value={customPromptInput}
+              onChange={(e) => setCustomPromptInput(e.target.value)}
+              placeholder="e.g. Trigger if all tests pass AND coverage > 80%"
+              style={{
+                width: "100%", minHeight: 80, padding: 8,
+                backgroundColor: "var(--q-bg-inset)", color: "var(--q-fg)",
+                border: "1px solid var(--q-border)", borderRadius: 4,
+                fontFamily: font, fontSize: 11, resize: "vertical",
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                  handleCustomPromptSubmit();
+                }
+              }}
+            />
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 12 }}>
+              <button
+                onClick={() => { setCustomPromptModal(null); setCustomPromptInput(""); }}
+                style={{
+                  background: "none", border: "1px solid var(--q-border)", borderRadius: 4,
+                  padding: "4px 12px", color: "var(--q-fg-secondary)", cursor: "pointer",
+                  fontFamily: font, fontSize: 10,
+                }}
+              >cancel</button>
+              <button
+                onClick={handleCustomPromptSubmit}
+                disabled={!customPromptInput.trim()}
+                style={{
+                  background: "#3B82F6", border: "none", borderRadius: 4,
+                  padding: "4px 12px", color: "#fff", cursor: customPromptInput.trim() ? "pointer" : "not-allowed",
+                  fontFamily: font, fontSize: 10, opacity: customPromptInput.trim() ? 1 : 0.5,
+                }}
+              >create trigger</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -118,15 +118,22 @@ export interface Job {
   envVariables: Record<string, string>;
   onSuccess: string[];
   onFailure: string[];
+  onCustom: CustomTriggerRef[];
   triggeredBy: TriggerRef[];
   workspaceId: string;
   createdAt: string;
   updatedAt: string;
 }
 
+export interface CustomTriggerRef {
+  targetJobId: string;
+  customPrompt: string;
+}
+
 export interface TriggerRef {
   jobId: string;
-  triggerOn: "success" | "failure";
+  triggerOn: "success" | "failure" | "custom";
+  customPrompt?: string;
 }
 
 export interface CreateJobRequest {
@@ -156,6 +163,7 @@ export interface CreateJobRequest {
   envVariables: Record<string, string>;
   onSuccess: string[];
   onFailure: string[];
+  onCustom: CustomTriggerRef[];
   workspaceId?: string;
 }
 

--- a/internal/application/adapter/job_manager.go
+++ b/internal/application/adapter/job_manager.go
@@ -6,12 +6,12 @@ import "quant/internal/domain/entity"
 // JobManager defines the service interface for job management operations.
 // This is the application adapter that the jobManagerService implements.
 type JobManager interface {
-	CreateJob(job entity.Job, onSuccess []string, onFailure []string) (*entity.Job, error)
-	UpdateJob(job entity.Job, onSuccess []string, onFailure []string) (*entity.Job, error)
+	CreateJob(job entity.Job, onSuccess []string, onFailure []string, onCustom []entity.CustomTriggerRef) (*entity.Job, error)
+	UpdateJob(job entity.Job, onSuccess []string, onFailure []string, onCustom []entity.CustomTriggerRef) (*entity.Job, error)
 	DeleteJob(id string) error
 	GetJob(id string) (*entity.Job, error)
 	ListJobs() ([]entity.Job, error)
-	GetTriggersForJob(jobID string) (onSuccess []entity.JobTrigger, onFailure []entity.JobTrigger, triggeredBy []entity.JobTrigger, err error)
+	GetTriggersForJob(jobID string) (onSuccess []entity.JobTrigger, onFailure []entity.JobTrigger, onCustom []entity.JobTrigger, triggeredBy []entity.JobTrigger, err error)
 	RunJob(jobID string, triggeredByRunID string, correlationID ...string) (*entity.JobRun, error)
 	RunJobWithContext(jobID string, context string) (*entity.JobRun, error)
 	RerunJob(jobID string, originalRunID string) (*entity.JobRun, error)

--- a/internal/application/service/job_manager.go
+++ b/internal/application/service/job_manager.go
@@ -69,7 +69,7 @@ func NewJobManagerService(
 }
 
 // CreateJob creates a new job with optional trigger chains.
-func (s *jobManagerService) CreateJob(job entity.Job, onSuccess []string, onFailure []string) (*entity.Job, error) {
+func (s *jobManagerService) CreateJob(job entity.Job, onSuccess []string, onFailure []string, onCustom []entity.CustomTriggerRef) (*entity.Job, error) {
 	now := time.Now()
 	job.ID = uuid.New().String()
 	job.CreatedAt = now
@@ -80,7 +80,7 @@ func (s *jobManagerService) CreateJob(job entity.Job, onSuccess []string, onFail
 		return nil, fmt.Errorf("failed to save job: %w", err)
 	}
 
-	err = s.createTriggers(job.ID, onSuccess, onFailure)
+	err = s.createTriggers(job.ID, onSuccess, onFailure, onCustom)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create triggers: %w", err)
 	}
@@ -89,7 +89,7 @@ func (s *jobManagerService) CreateJob(job entity.Job, onSuccess []string, onFail
 }
 
 // UpdateJob updates an existing job and replaces its trigger chains.
-func (s *jobManagerService) UpdateJob(job entity.Job, onSuccess []string, onFailure []string) (*entity.Job, error) {
+func (s *jobManagerService) UpdateJob(job entity.Job, onSuccess []string, onFailure []string, onCustom []entity.CustomTriggerRef) (*entity.Job, error) {
 	existing, err := s.findJob.FindJobByID(job.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find job: %w", err)
@@ -112,7 +112,7 @@ func (s *jobManagerService) UpdateJob(job entity.Job, onSuccess []string, onFail
 		return nil, fmt.Errorf("failed to delete existing triggers: %w", err)
 	}
 
-	err = s.createTriggers(job.ID, onSuccess, onFailure)
+	err = s.createTriggers(job.ID, onSuccess, onFailure, onCustom)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create triggers: %w", err)
 	}
@@ -170,11 +170,11 @@ func (s *jobManagerService) ListJobs() ([]entity.Job, error) {
 }
 
 // GetTriggersForJob returns triggers organized by relationship and outcome.
-func (s *jobManagerService) GetTriggersForJob(jobID string) (onSuccess []entity.JobTrigger, onFailure []entity.JobTrigger, triggeredBy []entity.JobTrigger, err error) {
+func (s *jobManagerService) GetTriggersForJob(jobID string) (onSuccess []entity.JobTrigger, onFailure []entity.JobTrigger, onCustom []entity.JobTrigger, triggeredBy []entity.JobTrigger, err error) {
 	// Find triggers where this job is the source (this job triggers others).
 	sourceTriggers, err := s.findJobTrigger.FindTriggersBySourceJobID(jobID)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to find source triggers: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to find source triggers: %w", err)
 	}
 
 	for _, t := range sourceTriggers {
@@ -183,16 +183,18 @@ func (s *jobManagerService) GetTriggersForJob(jobID string) (onSuccess []entity.
 			onSuccess = append(onSuccess, t)
 		case "failure":
 			onFailure = append(onFailure, t)
+		case "custom":
+			onCustom = append(onCustom, t)
 		}
 	}
 
 	// Find triggers where this job is the target (other jobs trigger this one).
 	triggeredBy, err = s.findJobTrigger.FindTriggersByTargetJobID(jobID)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to find target triggers: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to find target triggers: %w", err)
 	}
 
-	return onSuccess, onFailure, triggeredBy, nil
+	return onSuccess, onFailure, onCustom, triggeredBy, nil
 }
 
 // RunJob starts a new run for a job. Supports retries with history for Claude jobs.
@@ -1253,37 +1255,61 @@ func (s *jobManagerService) fireTriggers(jobID string, run *entity.JobRun) {
 	}
 
 	for _, trigger := range triggers {
+		shouldFire := false
 		if trigger.TriggerOn == triggerOn {
-			// Build trigger context — prefer structured metadata over raw output
-			var ctx string
-			if metadataSection != "" {
-				ctx = fmt.Sprintf(
-					"## Trigger context\n"+
-						"This job was triggered by the %s of job \"%s\" (run: %s).\n"+
-						"\n### Structured metadata from \"%s\":\n```json\n%s\n```\n",
-					triggerOn, sourceJobName, run.ID, sourceJobName, metadataSection,
-				)
-			} else {
-				ctx = fmt.Sprintf(
-					"## Trigger context\n"+
-						"This job was triggered by the %s of job \"%s\" (run: %s).\n"+
-						"\n### Output from \"%s\":\n```\n%s\n```\n",
-					triggerOn, sourceJobName, run.ID, sourceJobName, sourceOutput,
-				)
-			}
+			shouldFire = true
+		} else if trigger.TriggerOn == "custom" {
+			// Custom triggers fire on any completion — the custom prompt provides evaluation context
+			shouldFire = true
+		}
 
-			// Store context for the new run to pick up
-			newRun, err := s.RunJob(trigger.TargetJobID, run.ID, run.CorrelationID)
-			if err == nil && newRun != nil {
-				s.mu.Lock()
-				// Append continue_pipeline context if present
-				if continueCtx, ok := s.triggerCtx["continue:"+run.ID]; ok {
-					ctx += fmt.Sprintf("\n## Human intervention context\n%s\n", continueCtx)
-					delete(s.triggerCtx, "continue:"+run.ID)
-				}
-				s.triggerCtx[newRun.ID] = ctx
-				s.mu.Unlock()
+		if !shouldFire {
+			continue
+		}
+
+		// Build trigger context — prefer structured metadata over raw output
+		var ctx string
+		if trigger.TriggerOn == "custom" {
+			// Include the custom evaluation prompt as part of the context
+			ctx = fmt.Sprintf(
+				"## Trigger context\n"+
+					"This job was triggered by a custom conditional trigger from job \"%s\" (run: %s).\n"+
+					"The job finished with status: %s.\n"+
+					"\n### Custom trigger condition:\n%s\n",
+				sourceJobName, run.ID, triggerOn, trigger.CustomPrompt,
+			)
+			if metadataSection != "" {
+				ctx += fmt.Sprintf("\n### Structured metadata from \"%s\":\n```json\n%s\n```\n", sourceJobName, metadataSection)
+			} else {
+				ctx += fmt.Sprintf("\n### Output from \"%s\":\n```\n%s\n```\n", sourceJobName, sourceOutput)
 			}
+		} else if metadataSection != "" {
+			ctx = fmt.Sprintf(
+				"## Trigger context\n"+
+					"This job was triggered by the %s of job \"%s\" (run: %s).\n"+
+					"\n### Structured metadata from \"%s\":\n```json\n%s\n```\n",
+				triggerOn, sourceJobName, run.ID, sourceJobName, metadataSection,
+			)
+		} else {
+			ctx = fmt.Sprintf(
+				"## Trigger context\n"+
+					"This job was triggered by the %s of job \"%s\" (run: %s).\n"+
+					"\n### Output from \"%s\":\n```\n%s\n```\n",
+				triggerOn, sourceJobName, run.ID, sourceJobName, sourceOutput,
+			)
+		}
+
+		// Store context for the new run to pick up
+		newRun, err := s.RunJob(trigger.TargetJobID, run.ID, run.CorrelationID)
+		if err == nil && newRun != nil {
+			s.mu.Lock()
+			// Append continue_pipeline context if present
+			if continueCtx, ok := s.triggerCtx["continue:"+run.ID]; ok {
+				ctx += fmt.Sprintf("\n## Human intervention context\n%s\n", continueCtx)
+				delete(s.triggerCtx, "continue:"+run.ID)
+			}
+			s.triggerCtx[newRun.ID] = ctx
+			s.mu.Unlock()
 		}
 	}
 }
@@ -1473,8 +1499,8 @@ func (s *jobManagerService) GetRunOutput(runID string) (string, error) {
 	return run.Result, nil
 }
 
-// createTriggers creates trigger records for on-success and on-failure target job IDs.
-func (s *jobManagerService) createTriggers(sourceJobID string, onSuccess []string, onFailure []string) error {
+// createTriggers creates trigger records for on-success, on-failure, and custom target job IDs.
+func (s *jobManagerService) createTriggers(sourceJobID string, onSuccess []string, onFailure []string, onCustom []entity.CustomTriggerRef) error {
 	for _, targetID := range onSuccess {
 		trigger := entity.JobTrigger{
 			ID:          uuid.New().String(),
@@ -1496,6 +1522,19 @@ func (s *jobManagerService) createTriggers(sourceJobID string, onSuccess []strin
 		}
 		if err := s.saveJobTrigger.SaveJobTrigger(trigger); err != nil {
 			return fmt.Errorf("failed to save failure trigger: %w", err)
+		}
+	}
+
+	for _, ref := range onCustom {
+		trigger := entity.JobTrigger{
+			ID:           uuid.New().String(),
+			SourceJobID:  sourceJobID,
+			TargetJobID:  ref.TargetJobID,
+			TriggerOn:    "custom",
+			CustomPrompt: ref.CustomPrompt,
+		}
+		if err := s.saveJobTrigger.SaveJobTrigger(trigger); err != nil {
+			return fmt.Errorf("failed to save custom trigger: %w", err)
 		}
 	}
 

--- a/internal/domain/entity/job_trigger.go
+++ b/internal/domain/entity/job_trigger.go
@@ -4,8 +4,15 @@ package entity
 // JobTrigger represents a trigger chain between two jobs.
 // When SourceJobID completes with the specified outcome, TargetJobID is executed.
 type JobTrigger struct {
-	ID          string
-	SourceJobID string // the job whose completion fires the trigger
-	TargetJobID string // the job to run
-	TriggerOn   string // "success" or "failure"
+	ID           string
+	SourceJobID  string // the job whose completion fires the trigger
+	TargetJobID  string // the job to run
+	TriggerOn    string // "success" | "failure" | "custom"
+	CustomPrompt string // per-trigger evaluation prompt, only used when TriggerOn == "custom"
+}
+
+// CustomTriggerRef is used in create/update requests to specify a custom trigger target and its prompt.
+type CustomTriggerRef struct {
+	TargetJobID  string `json:"targetJobId"`
+	CustomPrompt string `json:"customPrompt"`
 }

--- a/internal/infra/db/sqlite.go
+++ b/internal/infra/db/sqlite.go
@@ -287,6 +287,7 @@ func runMigrations(db *sql.DB) error {
 		`ALTER TABLE jobs ADD COLUMN triage_prompt TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE job_runs ADD COLUMN correlation_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE job_runs ADD COLUMN injected_context TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE job_triggers ADD COLUMN custom_prompt TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range alterStatements {
 		// Ignore errors from ALTER TABLE since the column may already exist.

--- a/internal/integration/entrypoint/controller/job.go
+++ b/internal/integration/entrypoint/controller/job.go
@@ -65,17 +65,17 @@ func (c *jobController) CreateJob(request dto.CreateJobRequest) (*dto.JobRespons
 		WorkspaceID:         request.WorkspaceID,
 	}
 
-	created, err := c.jobManager.CreateJob(job, request.OnSuccess, request.OnFailure)
+	created, err := c.jobManager.CreateJob(job, request.OnSuccess, request.OnFailure, request.OnCustom)
 	if err != nil {
 		return nil, err
 	}
 
-	onSuccess, onFailure, triggeredBy, err := c.jobManager.GetTriggersForJob(created.ID)
+	onSuccess, onFailure, onCustom, triggeredBy, err := c.jobManager.GetTriggersForJob(created.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	return dto.JobResponseFromEntityPtr(created, onSuccess, onFailure, triggeredBy), nil
+	return dto.JobResponseFromEntityPtr(created, onSuccess, onFailure, onCustom, triggeredBy), nil
 }
 
 // UpdateJob updates an existing job and returns its response DTO.
@@ -109,17 +109,17 @@ func (c *jobController) UpdateJob(request dto.UpdateJobRequest) (*dto.JobRespons
 		WorkspaceID:         request.WorkspaceID,
 	}
 
-	updated, err := c.jobManager.UpdateJob(job, request.OnSuccess, request.OnFailure)
+	updated, err := c.jobManager.UpdateJob(job, request.OnSuccess, request.OnFailure, request.OnCustom)
 	if err != nil {
 		return nil, err
 	}
 
-	onSuccess, onFailure, triggeredBy, err := c.jobManager.GetTriggersForJob(updated.ID)
+	onSuccess, onFailure, onCustom, triggeredBy, err := c.jobManager.GetTriggersForJob(updated.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	return dto.JobResponseFromEntityPtr(updated, onSuccess, onFailure, triggeredBy), nil
+	return dto.JobResponseFromEntityPtr(updated, onSuccess, onFailure, onCustom, triggeredBy), nil
 }
 
 // DeleteJob deletes a job by ID.
@@ -134,12 +134,12 @@ func (c *jobController) GetJob(id string) (*dto.JobResponse, error) {
 		return nil, err
 	}
 
-	onSuccess, onFailure, triggeredBy, err := c.jobManager.GetTriggersForJob(job.ID)
+	onSuccess, onFailure, onCustom, triggeredBy, err := c.jobManager.GetTriggersForJob(job.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	return dto.JobResponseFromEntityPtr(job, onSuccess, onFailure, triggeredBy), nil
+	return dto.JobResponseFromEntityPtr(job, onSuccess, onFailure, onCustom, triggeredBy), nil
 }
 
 // ListJobs returns all jobs as response DTOs.

--- a/internal/integration/entrypoint/dto/job.go
+++ b/internal/integration/entrypoint/dto/job.go
@@ -31,9 +31,10 @@ type CreateJobRequest struct {
 	Interpreter         string            `json:"interpreter"`
 	ScriptContent       string            `json:"scriptContent"`
 	EnvVariables        map[string]string `json:"envVariables"`
-	OnSuccess           []string          `json:"onSuccess"`
-	OnFailure           []string          `json:"onFailure"`
-	WorkspaceID         string            `json:"workspaceId"`
+	OnSuccess           []string               `json:"onSuccess"`
+	OnFailure           []string               `json:"onFailure"`
+	OnCustom            []entity.CustomTriggerRef `json:"onCustom"`
+	WorkspaceID         string                 `json:"workspaceId"`
 }
 
 // UpdateJobRequest represents the request payload for updating an existing job.
@@ -63,9 +64,10 @@ type UpdateJobRequest struct {
 	Interpreter         string            `json:"interpreter"`
 	ScriptContent       string            `json:"scriptContent"`
 	EnvVariables        map[string]string `json:"envVariables"`
-	OnSuccess           []string          `json:"onSuccess"`
-	OnFailure           []string          `json:"onFailure"`
-	WorkspaceID         string            `json:"workspaceId"`
+	OnSuccess           []string               `json:"onSuccess"`
+	OnFailure           []string               `json:"onFailure"`
+	OnCustom            []entity.CustomTriggerRef `json:"onCustom"`
+	WorkspaceID         string                 `json:"workspaceId"`
 }
 
 // JobResponse represents the response payload for job data.
@@ -98,15 +100,23 @@ type JobResponse struct {
 	WorkspaceID         string            `json:"workspaceId"`
 	CreatedAt           string            `json:"createdAt"`
 	UpdatedAt           string            `json:"updatedAt"`
-	OnSuccess           []string          `json:"onSuccess"`
-	OnFailure           []string          `json:"onFailure"`
-	TriggeredBy         []TriggerRef      `json:"triggeredBy"`
+	OnSuccess           []string               `json:"onSuccess"`
+	OnFailure           []string               `json:"onFailure"`
+	OnCustom            []CustomTriggerResponse `json:"onCustom"`
+	TriggeredBy         []TriggerRef           `json:"triggeredBy"`
+}
+
+// CustomTriggerResponse represents a custom trigger in the job response.
+type CustomTriggerResponse struct {
+	TargetJobID  string `json:"targetJobId"`
+	CustomPrompt string `json:"customPrompt"`
 }
 
 // TriggerRef describes a trigger relationship with its type.
 type TriggerRef struct {
-	JobID     string `json:"jobId"`
-	TriggerOn string `json:"triggerOn"` // "success" or "failure"
+	JobID        string `json:"jobId"`
+	TriggerOn    string `json:"triggerOn"`    // "success" | "failure" | "custom"
+	CustomPrompt string `json:"customPrompt"` // only set when TriggerOn == "custom"
 }
 
 // JobRunResponse represents the response payload for job run data.
@@ -128,7 +138,7 @@ type JobRunResponse struct {
 }
 
 // JobResponseFromEntity converts a domain entity to a JobResponse DTO with trigger information.
-func JobResponseFromEntity(job entity.Job, onSuccess []entity.JobTrigger, onFailure []entity.JobTrigger, triggeredBy []entity.JobTrigger) JobResponse {
+func JobResponseFromEntity(job entity.Job, onSuccess []entity.JobTrigger, onFailure []entity.JobTrigger, onCustom []entity.JobTrigger, triggeredBy []entity.JobTrigger) JobResponse {
 	successIDs := make([]string, len(onSuccess))
 	for i, t := range onSuccess {
 		successIDs[i] = t.TargetJobID
@@ -139,9 +149,14 @@ func JobResponseFromEntity(job entity.Job, onSuccess []entity.JobTrigger, onFail
 		failureIDs[i] = t.TargetJobID
 	}
 
+	customTriggers := make([]CustomTriggerResponse, len(onCustom))
+	for i, t := range onCustom {
+		customTriggers[i] = CustomTriggerResponse{TargetJobID: t.TargetJobID, CustomPrompt: t.CustomPrompt}
+	}
+
 	triggeredByRefs := make([]TriggerRef, len(triggeredBy))
 	for i, t := range triggeredBy {
-		triggeredByRefs[i] = TriggerRef{JobID: t.SourceJobID, TriggerOn: t.TriggerOn}
+		triggeredByRefs[i] = TriggerRef{JobID: t.SourceJobID, TriggerOn: t.TriggerOn, CustomPrompt: t.CustomPrompt}
 	}
 
 	return JobResponse{
@@ -175,28 +190,29 @@ func JobResponseFromEntity(job entity.Job, onSuccess []entity.JobTrigger, onFail
 		UpdatedAt:           job.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
 		OnSuccess:           successIDs,
 		OnFailure:           failureIDs,
+		OnCustom:            customTriggers,
 		TriggeredBy:         triggeredByRefs,
 	}
 }
 
 // JobResponseFromEntityPtr converts a domain entity pointer to a JobResponse DTO pointer.
-func JobResponseFromEntityPtr(job *entity.Job, onSuccess []entity.JobTrigger, onFailure []entity.JobTrigger, triggeredBy []entity.JobTrigger) *JobResponse {
+func JobResponseFromEntityPtr(job *entity.Job, onSuccess []entity.JobTrigger, onFailure []entity.JobTrigger, onCustom []entity.JobTrigger, triggeredBy []entity.JobTrigger) *JobResponse {
 	if job == nil {
 		return nil
 	}
-	response := JobResponseFromEntity(*job, onSuccess, onFailure, triggeredBy)
+	response := JobResponseFromEntity(*job, onSuccess, onFailure, onCustom, triggeredBy)
 	return &response
 }
 
 // JobResponseListFromEntities converts a slice of jobs with their triggers to a slice of JobResponse DTOs.
-func JobResponseListFromEntities(jobs []entity.Job, triggersFn func(jobID string) ([]entity.JobTrigger, []entity.JobTrigger, []entity.JobTrigger, error)) ([]JobResponse, error) {
+func JobResponseListFromEntities(jobs []entity.Job, triggersFn func(jobID string) ([]entity.JobTrigger, []entity.JobTrigger, []entity.JobTrigger, []entity.JobTrigger, error)) ([]JobResponse, error) {
 	responses := make([]JobResponse, len(jobs))
 	for i, job := range jobs {
-		onSuccess, onFailure, triggeredBy, err := triggersFn(job.ID)
+		onSuccess, onFailure, onCustom, triggeredBy, err := triggersFn(job.ID)
 		if err != nil {
 			return nil, err
 		}
-		responses[i] = JobResponseFromEntity(job, onSuccess, onFailure, triggeredBy)
+		responses[i] = JobResponseFromEntity(job, onSuccess, onFailure, onCustom, triggeredBy)
 	}
 	return responses, nil
 }

--- a/internal/integration/mcp/server.go
+++ b/internal/integration/mcp/server.go
@@ -183,6 +183,7 @@ Returns the created job object with the generated ID. Use this ID for run_job, u
 			// Triggers
 			mcp.WithString("onSuccess", mcp.Description("JSON array of job IDs to trigger on success. E.g. '[\"job-id-1\",\"job-id-2\"]'. All listed jobs run in parallel. Use list_jobs to get IDs")),
 			mcp.WithString("onFailure", mcp.Description("JSON array of job IDs to trigger on failure. E.g. '[\"job-id-1\"]'. All listed jobs run in parallel. Use list_jobs to get IDs")),
+			mcp.WithString("onCustom", mcp.Description("JSON array of custom conditional triggers. Each has a per-trigger evaluation prompt. E.g. '[{\"targetJobId\":\"job-uuid\",\"customPrompt\":\"Trigger if the PR has more than 3 approvals\"}]'. Custom triggers fire on any job completion and include the prompt as context")),
 			// Flags
 			mcp.WithBoolean("allowBypass", mcp.Description("Allow --dangerously-skip-permissions flag for claude jobs. Default: true. Set to false to require manual permission grants during execution")),
 			mcp.WithBoolean("autonomousMode", mcp.Description("Run in autonomous mode without stopping to ask the user. Default: true. Set to false for interactive jobs that need human approval")),
@@ -232,6 +233,7 @@ Common workflows:
 			mcp.WithString("envVariables", mcp.Description("JSON object of env vars. E.g. '{\"KEY\":\"value\"}'. Replaces existing env vars")),
 			mcp.WithString("onSuccess", mcp.Description("JSON array of job IDs to trigger on success. E.g. '[\"id1\",\"id2\"]'. Replaces existing triggers")),
 			mcp.WithString("onFailure", mcp.Description("JSON array of job IDs to trigger on failure. E.g. '[\"id1\"]'. Replaces existing triggers")),
+			mcp.WithString("onCustom", mcp.Description("JSON array of custom conditional triggers. E.g. '[{\"targetJobId\":\"job-uuid\",\"customPrompt\":\"Trigger if coverage > 80%\"}]'. Replaces existing custom triggers")),
 			mcp.WithBoolean("allowBypass", mcp.Description("Allow --dangerously-skip-permissions for claude jobs")),
 			mcp.WithBoolean("autonomousMode", mcp.Description("Run without stopping to ask the user")),
 		),
@@ -427,6 +429,7 @@ Each object contains:
 - job_name: human-readable name
 - on_success: array of job names this job triggers on success
 - on_failure: array of job names this job triggers on failure
+- on_custom: array of {job_name, prompt} for custom conditional triggers
 - triggered_by: array of job names that can trigger this job
 
 Only includes jobs that have at least one trigger connection. Use this to:
@@ -989,8 +992,9 @@ func (s *QuantMCPServer) handleCreateJob(_ context.Context, request mcp.CallTool
 
 	onSuccess := stringSliceArg(args, "onSuccess")
 	onFailure := stringSliceArg(args, "onFailure")
+	onCustom := customTriggerSliceArg(args, "onCustom")
 
-	created, err := s.jobManager.CreateJob(job, onSuccess, onFailure)
+	created, err := s.jobManager.CreateJob(job, onSuccess, onFailure, onCustom)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -1091,10 +1095,11 @@ func (s *QuantMCPServer) handleUpdateJob(_ context.Context, request mcp.CallTool
 	// Only update triggers if explicitly provided — nil means "don't change"
 	onSuccess := stringSliceArg(args, "onSuccess")
 	onFailure := stringSliceArg(args, "onFailure")
+	onCustom := customTriggerSliceArg(args, "onCustom")
 
-	// If neither provided, preserve existing triggers
-	if onSuccess == nil && onFailure == nil {
-		existingSuccess, existingFailure, _, _ := s.jobManager.GetTriggersForJob(id)
+	// If none provided, preserve existing triggers
+	if onSuccess == nil && onFailure == nil && onCustom == nil {
+		existingSuccess, existingFailure, existingCustom, _, _ := s.jobManager.GetTriggersForJob(id)
 		onSuccess = make([]string, len(existingSuccess))
 		for i, t := range existingSuccess {
 			onSuccess[i] = t.TargetJobID
@@ -1103,9 +1108,20 @@ func (s *QuantMCPServer) handleUpdateJob(_ context.Context, request mcp.CallTool
 		for i, t := range existingFailure {
 			onFailure[i] = t.TargetJobID
 		}
+		onCustom = make([]entity.CustomTriggerRef, len(existingCustom))
+		for i, t := range existingCustom {
+			onCustom[i] = entity.CustomTriggerRef{TargetJobID: t.TargetJobID, CustomPrompt: t.CustomPrompt}
+		}
+	} else if onCustom == nil {
+		// If success/failure provided but not custom, preserve existing custom triggers
+		_, _, existingCustom, _, _ := s.jobManager.GetTriggersForJob(id)
+		onCustom = make([]entity.CustomTriggerRef, len(existingCustom))
+		for i, t := range existingCustom {
+			onCustom[i] = entity.CustomTriggerRef{TargetJobID: t.TargetJobID, CustomPrompt: t.CustomPrompt}
+		}
 	}
 
-	updated, err := s.jobManager.UpdateJob(*existing, onSuccess, onFailure)
+	updated, err := s.jobManager.UpdateJob(*existing, onSuccess, onFailure, onCustom)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -1353,12 +1369,18 @@ func (s *QuantMCPServer) handleGetTriggers(_ context.Context, _ mcp.CallToolRequ
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	type customTriggerInfo struct {
+		JobName string `json:"job_name"`
+		Prompt  string `json:"prompt"`
+	}
+
 	type triggerInfo struct {
-		JobID       string   `json:"job_id"`
-		JobName     string   `json:"job_name"`
-		OnSuccess   []string `json:"on_success"`
-		OnFailure   []string `json:"on_failure"`
-		TriggeredBy []string `json:"triggered_by"`
+		JobID       string              `json:"job_id"`
+		JobName     string              `json:"job_name"`
+		OnSuccess   []string            `json:"on_success"`
+		OnFailure   []string            `json:"on_failure"`
+		OnCustom    []customTriggerInfo `json:"on_custom,omitempty"`
+		TriggeredBy []string            `json:"triggered_by"`
 	}
 
 	// Build name lookup
@@ -1369,7 +1391,7 @@ func (s *QuantMCPServer) handleGetTriggers(_ context.Context, _ mcp.CallToolRequ
 
 	var result []triggerInfo
 	for _, j := range jobs {
-		onSuccess, onFailure, triggeredBy, err := s.jobManager.GetTriggersForJob(j.ID)
+		onSuccess, onFailure, onCustom, triggeredBy, err := s.jobManager.GetTriggersForJob(j.ID)
 		if err != nil {
 			continue
 		}
@@ -1392,6 +1414,13 @@ func (s *QuantMCPServer) handleGetTriggers(_ context.Context, _ mcp.CallToolRequ
 			}
 			info.OnFailure = append(info.OnFailure, name)
 		}
+		for _, t := range onCustom {
+			name := nameMap[t.TargetJobID]
+			if name == "" {
+				name = t.TargetJobID
+			}
+			info.OnCustom = append(info.OnCustom, customTriggerInfo{JobName: name, Prompt: t.CustomPrompt})
+		}
 		for _, t := range triggeredBy {
 			name := nameMap[t.SourceJobID]
 			if name == "" {
@@ -1401,7 +1430,7 @@ func (s *QuantMCPServer) handleGetTriggers(_ context.Context, _ mcp.CallToolRequ
 		}
 
 		// Only include jobs that have any trigger connections
-		if len(info.OnSuccess) > 0 || len(info.OnFailure) > 0 || len(info.TriggeredBy) > 0 {
+		if len(info.OnSuccess) > 0 || len(info.OnFailure) > 0 || len(info.OnCustom) > 0 || len(info.TriggeredBy) > 0 {
 			result = append(result, info)
 		}
 	}
@@ -2021,7 +2050,7 @@ func (s *QuantMCPServer) handleMoveJobToWorkspace(_ context.Context, request mcp
 	job.WorkspaceID = workspaceID
 
 	// Preserve existing triggers
-	existingSuccess, existingFailure, _, _ := s.jobManager.GetTriggersForJob(jobID)
+	existingSuccess, existingFailure, existingCustom, _, _ := s.jobManager.GetTriggersForJob(jobID)
 	onSuccess := make([]string, len(existingSuccess))
 	for i, t := range existingSuccess {
 		onSuccess[i] = t.TargetJobID
@@ -2030,8 +2059,12 @@ func (s *QuantMCPServer) handleMoveJobToWorkspace(_ context.Context, request mcp
 	for i, t := range existingFailure {
 		onFailure[i] = t.TargetJobID
 	}
+	onCustom := make([]entity.CustomTriggerRef, len(existingCustom))
+	for i, t := range existingCustom {
+		onCustom[i] = entity.CustomTriggerRef{TargetJobID: t.TargetJobID, CustomPrompt: t.CustomPrompt}
+	}
 
-	updated, err := s.jobManager.UpdateJob(*job, onSuccess, onFailure)
+	updated, err := s.jobManager.UpdateJob(*job, onSuccess, onFailure, onCustom)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -2295,7 +2328,7 @@ func (s *QuantMCPServer) handleMoveGroupToWorkspace(_ context.Context, request m
 			continue
 		}
 		job.WorkspaceID = workspaceID
-		onSuccess, onFailure, _, _ := s.jobManager.GetTriggersForJob(jobID)
+		onSuccess, onFailure, onCustom, _, _ := s.jobManager.GetTriggersForJob(jobID)
 		successIDs := make([]string, len(onSuccess))
 		for i, t := range onSuccess {
 			successIDs[i] = t.TargetJobID
@@ -2304,7 +2337,11 @@ func (s *QuantMCPServer) handleMoveGroupToWorkspace(_ context.Context, request m
 		for i, t := range onFailure {
 			failureIDs[i] = t.TargetJobID
 		}
-		_, _ = s.jobManager.UpdateJob(*job, successIDs, failureIDs)
+		customRefs := make([]entity.CustomTriggerRef, len(onCustom))
+		for i, t := range onCustom {
+			customRefs[i] = entity.CustomTriggerRef{TargetJobID: t.TargetJobID, CustomPrompt: t.CustomPrompt}
+		}
+		_, _ = s.jobManager.UpdateJob(*job, successIDs, failureIDs, customRefs)
 	}
 
 	return mcp.NewToolResultText(fmt.Sprintf("moved group '%s' and %d jobs to workspace %s", existing.Name, len(existing.JobIDs), workspaceID)), nil
@@ -2643,6 +2680,46 @@ func mapStringArg(args map[string]any, key string) map[string]string {
 			return result
 		}
 	}
+	return nil
+}
+
+func customTriggerSliceArg(args map[string]any, key string) []entity.CustomTriggerRef {
+	v, ok := args[key]
+	if !ok || v == nil {
+		return nil
+	}
+
+	// Handle []any (from native JSON arrays)
+	if arr, ok := v.([]any); ok {
+		result := make([]entity.CustomTriggerRef, 0, len(arr))
+		for _, item := range arr {
+			if m, ok := item.(map[string]any); ok {
+				ref := entity.CustomTriggerRef{}
+				if tid, ok := m["targetJobId"].(string); ok {
+					ref.TargetJobID = tid
+				}
+				if cp, ok := m["customPrompt"].(string); ok {
+					ref.CustomPrompt = cp
+				}
+				if ref.TargetJobID != "" {
+					result = append(result, ref)
+				}
+			}
+		}
+		return result
+	}
+
+	// Handle string (JSON-encoded array from MCP string field)
+	if s, ok := v.(string); ok && s != "" {
+		s = strings.TrimSpace(s)
+		if strings.HasPrefix(s, "[") {
+			var result []entity.CustomTriggerRef
+			if err := json.Unmarshal([]byte(s), &result); err == nil {
+				return result
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/internal/integration/persistence/dto/job_trigger.go
+++ b/internal/integration/persistence/dto/job_trigger.go
@@ -7,28 +7,31 @@ import (
 
 // JobTriggerRow represents a job trigger row in the SQLite database.
 type JobTriggerRow struct {
-	ID          string
-	SourceJobID string
-	TargetJobID string
-	TriggerOn   string
+	ID           string
+	SourceJobID  string
+	TargetJobID  string
+	TriggerOn    string
+	CustomPrompt string
 }
 
 // ToEntity converts a JobTriggerRow to a domain entity.
 func (r JobTriggerRow) ToEntity() entity.JobTrigger {
 	return entity.JobTrigger{
-		ID:          r.ID,
-		SourceJobID: r.SourceJobID,
-		TargetJobID: r.TargetJobID,
-		TriggerOn:   r.TriggerOn,
+		ID:           r.ID,
+		SourceJobID:  r.SourceJobID,
+		TargetJobID:  r.TargetJobID,
+		TriggerOn:    r.TriggerOn,
+		CustomPrompt: r.CustomPrompt,
 	}
 }
 
 // JobTriggerRowFromEntity converts a domain entity to a JobTriggerRow.
 func JobTriggerRowFromEntity(trigger entity.JobTrigger) JobTriggerRow {
 	return JobTriggerRow{
-		ID:          trigger.ID,
-		SourceJobID: trigger.SourceJobID,
-		TargetJobID: trigger.TargetJobID,
-		TriggerOn:   trigger.TriggerOn,
+		ID:           trigger.ID,
+		SourceJobID:  trigger.SourceJobID,
+		TargetJobID:  trigger.TargetJobID,
+		TriggerOn:    trigger.TriggerOn,
+		CustomPrompt: trigger.CustomPrompt,
 	}
 }

--- a/internal/integration/persistence/job.go
+++ b/internal/integration/persistence/job.go
@@ -26,7 +26,7 @@ const jobColumns = `id, name, description, type, working_directory, schedule_ena
 		max_retries, model, override_repo_command, claude_command, agent_id, success_prompt, failure_prompt, metadata_prompt, triage_prompt,
 		interpreter, script_content, env_variables, workspace_id, created_at, updated_at, last_run_at`
 
-const jobTriggerColumns = `id, source_job_id, target_job_id, trigger_on`
+const jobTriggerColumns = `id, source_job_id, target_job_id, trigger_on, custom_prompt`
 
 const jobRunColumns = `id, job_id, status, triggered_by, correlation_id, session_id, model_used, duration_ms, tokens_used, result,
 		error_message, injected_context, started_at, finished_at`
@@ -49,7 +49,7 @@ func scanJobRow(scanner interface{ Scan(...any) error }) (pdto.JobRow, error) {
 func scanJobTriggerRow(scanner interface{ Scan(...any) error }) (pdto.JobTriggerRow, error) {
 	var row pdto.JobTriggerRow
 	err := scanner.Scan(
-		&row.ID, &row.SourceJobID, &row.TargetJobID, &row.TriggerOn,
+		&row.ID, &row.SourceJobID, &row.TargetJobID, &row.TriggerOn, &row.CustomPrompt,
 	)
 	return row, err
 }
@@ -275,10 +275,10 @@ func (p *jobPersistence) FindTriggersByTargetJobID(jobID string) ([]entity.JobTr
 func (p *jobPersistence) SaveJobTrigger(trigger entity.JobTrigger) error {
 	row := pdto.JobTriggerRowFromEntity(trigger)
 
-	query := `INSERT INTO job_triggers (id, source_job_id, target_job_id, trigger_on)
-		VALUES (?, ?, ?, ?)`
+	query := `INSERT INTO job_triggers (id, source_job_id, target_job_id, trigger_on, custom_prompt)
+		VALUES (?, ?, ?, ?, ?)`
 
-	_, err := p.db.Exec(query, row.ID, row.SourceJobID, row.TargetJobID, row.TriggerOn)
+	_, err := p.db.Exec(query, row.ID, row.SourceJobID, row.TargetJobID, row.TriggerOn, row.CustomPrompt)
 	if err != nil {
 		return fmt.Errorf("failed to save job trigger: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Adds a third trigger type — **custom conditional triggers** — where the evaluation prompt lives on the trigger edge itself, not on the source job
- Blue (#3B82F6) dashed edges on the canvas distinguish custom triggers from success (green) and failure (red)
- Custom prompt modal appears when connecting two jobs in "on custom" mode
- Full backend support: domain entity, persistence, service, controller, MCP tools (`create_job`, `update_job`, `get_job`, `get_triggers`)

Closes #13

## Changes across layers
| Layer | Files |
|-------|-------|
| Domain | `job_trigger.go` — added `CustomPrompt` field and `CustomTriggerRef` type |
| DB | `sqlite.go` — `ALTER TABLE job_triggers ADD COLUMN custom_prompt` |
| Persistence | `job.go`, `dto/job_trigger.go` — SQL + DTO updated for new column |
| Application | `job_manager.go`, `adapter/job_manager.go` — `createTriggers`, `fireTriggers`, `GetTriggersForJob` handle custom type |
| Controller | `controller/job.go`, `dto/job.go` — pass `onCustom` through, `CustomTriggerResponse` in response |
| MCP | `server.go` — `onCustom` parameter on `create_job`/`update_job`, `on_custom` in `get_triggers` |
| Frontend | `types.ts`, `JobsView.tsx`, `CreateJobModal.tsx` — dropdown option, edge rendering, prompt modal, detail panel |

## Test plan
- [x] `go vet ./internal/...` passes
- [x] `go build .` (full Wails app) passes
- [x] `tsc --noEmit` (frontend types) passes
- [x] `vite build` (production bundle) passes
- [x] Custom trigger code verified in built JS bundle
- [ ] Manual E2E: create two jobs, connect with "on custom", verify blue edge + prompt modal
- [ ] Manual E2E: run source job, verify custom trigger fires downstream job with prompt context
- [ ] Manual E2E: delete custom edge via click and keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)