### PR TITLE
feat(issue-49): recent repos dropdown on `+ repo` for fast reopening

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,20 +1,33 @@
 {
   "entries": [
     {
-      "version": "v3.1.17",
+      "version": "v3.1.16",
       "date": "2026-04-14",
       "changes": {
+        "internal": [
+          "update changelog for v3.1.15 and v3.1.16"
+        ],
         "features": [
-          "drag whole group by grabbing the group name label on the jobs canvas"
+          "drag whole group by grabbing the group name label"
+        ],
+        "fixes": [
+          "prevent canvas position reset on workspace switch"
         ]
       }
     },
     {
-      "version": "v3.1.16",
-      "date": "2026-04-14",
+      "version": "v3.1.15",
+      "date": "2026-04-13",
       "changes": {
+        "internal": [
+          "update changelog for recent versions and fixes"
+        ],
+        "features": [
+          "add notification management functions to runtime",
+          "share Claude session across correlated jobs in a chain"
+        ],
         "fixes": [
-          "prevent canvas position reset and minimap vanish when switching workspaces"
+          "resolve FK violation and revert fireTriggers to use RunJob"
         ]
       }
     },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -744,6 +744,20 @@ function App() {
     }
   }
 
+  async function handleReopenRecentRepo(repo: { name: string; path: string }) {
+    try {
+      setError(null);
+      await api.openRepo({
+        name: repo.name,
+        path: repo.path,
+        workspaceId: activeWorkspaceId,
+      });
+      await loadAll();
+    } catch (err) {
+      setError(String(err));
+    }
+  }
+
   async function handleCreateTask(req: CreateTaskRequest) {
     try {
       setError(null);
@@ -1893,6 +1907,8 @@ function App() {
         onExpandSession={setExpandedSessionId}
         onOpenTab={handleOpenTab}
         onOpenRepo={() => setModal({ type: "openRepo" })}
+        onReopenRepo={handleReopenRecentRepo}
+        workspaceId={activeWorkspaceId}
         onCreateTask={(repoId) => setModal({ type: "newTask", repoId })}
         onCreateSession={(repoId, taskId) =>
           setModal({ type: "newSession", repoId, taskId })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -57,6 +57,14 @@ export function listReposByWorkspace(workspaceId: string): Promise<Repo[]> {
   return callGo(PKG, REPO_CTRL, "ListReposByWorkspace", workspaceId);
 }
 
+export function listClosedReposByWorkspace(
+  workspaceId: string,
+  limit: number,
+  offset: number
+): Promise<Repo[]> {
+  return callGo(PKG, REPO_CTRL, "ListClosedReposByWorkspace", workspaceId, limit, offset);
+}
+
 export function getRepo(id: string): Promise<Repo> {
   return callGo(PKG, REPO_CTRL, "GetRepo", id);
 }

--- a/frontend/src/components/RecentReposDropdown.tsx
+++ b/frontend/src/components/RecentReposDropdown.tsx
@@ -1,0 +1,330 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Repo } from "../types";
+import * as api from "../api";
+
+const PAGE_SIZE = 20;
+
+interface Props {
+  workspaceId: string;
+  anchorRect: DOMRect;
+  onSelect: (repo: Repo) => void;
+  onOpenNewPath: () => void;
+  onClose: () => void;
+}
+
+function relativeTime(iso?: string): string {
+  if (!iso) return "";
+  const then = new Date(iso).getTime();
+  if (isNaN(then)) return "";
+  const diff = Date.now() - then;
+  const sec = Math.max(1, Math.floor(diff / 1000));
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  const wk = Math.floor(day / 7);
+  if (wk < 5) return `${wk}w ago`;
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.floor(day / 365)}y ago`;
+}
+
+export function RecentReposDropdown({
+  workspaceId,
+  anchorRect,
+  onSelect,
+  onOpenNewPath,
+  onClose,
+}: Props) {
+  const [repos, setRepos] = useState<Repo[]>([]);
+  const [filter, setFilter] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(true);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [emptyChecked, setEmptyChecked] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const offsetRef = useRef(0);
+  const loadingMoreRef = useRef(false);
+
+  const filtered = filter
+    ? repos.filter((r) => {
+        const q = filter.toLowerCase();
+        return r.name.toLowerCase().includes(q) || r.path.toLowerCase().includes(q);
+      })
+    : repos;
+
+  // total entries in the keyboard-navigable list: filtered repos + "open new path" at bottom
+  const totalEntries = filtered.length + 1;
+  const openNewPathIndex = filtered.length;
+
+  const loadPage = useCallback(async () => {
+    if (loadingMoreRef.current) return;
+    loadingMoreRef.current = true;
+    try {
+      const page = await api.listClosedReposByWorkspace(workspaceId, PAGE_SIZE, offsetRef.current);
+      setRepos((prev) => [...prev, ...page]);
+      offsetRef.current += page.length;
+      if (page.length < PAGE_SIZE) setHasMore(false);
+    } catch (err) {
+      console.error("listClosedReposByWorkspace failed:", err);
+      setHasMore(false);
+    } finally {
+      loadingMoreRef.current = false;
+      setLoading(false);
+    }
+  }, [workspaceId]);
+
+  // initial load
+  useEffect(() => {
+    loadPage().then(() => setEmptyChecked(true));
+  }, [loadPage]);
+
+  // if the workspace has no closed repos at all, fall through to the OpenRepoModal directly
+  useEffect(() => {
+    if (emptyChecked && repos.length === 0) {
+      onOpenNewPath();
+    }
+  }, [emptyChecked, repos.length, onOpenNewPath]);
+
+  // close on outside click
+  useEffect(() => {
+    function handleMouseDown(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [onClose]);
+
+  // focus filter input on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // reset selection when filter changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [filter]);
+
+  // scroll selected item into view
+  useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const item = el.children[selectedIndex] as HTMLElement | undefined;
+    if (item) item.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  function handleScroll(e: React.UIEvent<HTMLDivElement>) {
+    if (!hasMore || loadingMoreRef.current || filter) return;
+    const el = e.currentTarget;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 80) {
+      loadPage();
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex((i) => (i + 1) % Math.max(totalEntries, 1));
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex((i) => (i - 1 + Math.max(totalEntries, 1)) % Math.max(totalEntries, 1));
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (selectedIndex === openNewPathIndex) {
+        onOpenNewPath();
+        return;
+      }
+      const repo = filtered[selectedIndex];
+      if (repo) onSelect(repo);
+    }
+  }
+
+  // hide entire dropdown until we know whether there are repos to show.
+  // if empty, the parent will switch to OpenRepoModal via onOpenNewPath.
+  if (!emptyChecked || repos.length === 0) return null;
+
+  // position the panel below the anchor button. Clamp to viewport.
+  const PANEL_WIDTH = 380;
+  const left = Math.max(8, Math.min(anchorRect.left, window.innerWidth - PANEL_WIDTH - 8));
+  const top = anchorRect.bottom + 4;
+
+  const font = "'JetBrains Mono', monospace";
+
+  return (
+    <div
+      ref={containerRef}
+      className="fixed z-50"
+      style={{
+        left,
+        top,
+        width: PANEL_WIDTH,
+        maxHeight: 380,
+        backgroundColor: "var(--q-bg)",
+        border: "1px solid var(--q-border)",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: font,
+      }}
+      onKeyDown={handleKeyDown}
+      data-testid="recent-repos-dropdown"
+    >
+      <div
+        className="px-3 py-2"
+        style={{ borderBottom: "1px solid var(--q-border)", color: "var(--q-fg)" }}
+      >
+        <span style={{ color: "var(--q-accent)" }}>{">"}</span>{" "}
+        <span style={{ fontSize: 11 }}>open_repo</span>
+      </div>
+
+      <div className="px-3 py-2" style={{ borderBottom: "1px solid var(--q-border)" }}>
+        <input
+          ref={inputRef}
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="filter recent repos..."
+          className="w-full px-2 py-1 text-xs focus:outline-none"
+          style={{
+            backgroundColor: "var(--q-bg)",
+            border: "1px solid var(--q-border)",
+            color: "var(--q-fg)",
+          }}
+          onFocus={(e) => (e.currentTarget.style.borderColor = "var(--q-accent)")}
+          onBlur={(e) => (e.currentTarget.style.borderColor = "var(--q-border)")}
+        />
+      </div>
+
+      <div
+        className="px-3 pt-2 pb-1"
+        style={{ fontSize: 9, color: "var(--q-fg-muted)" }}
+      >
+        recent
+      </div>
+
+      <div
+        ref={listRef}
+        onScroll={handleScroll}
+        style={{ flex: 1, overflowY: "auto", minHeight: 0 }}
+      >
+        {filtered.length === 0 ? (
+          <div
+            className="px-3 py-4 text-center"
+            style={{ fontSize: 11, color: "var(--q-fg-muted)" }}
+          >
+            no repos match
+          </div>
+        ) : (
+          filtered.map((repo, i) => {
+            const selected = i === selectedIndex;
+            return (
+              <button
+                key={repo.id}
+                data-testid="recent-repo-item"
+                onClick={() => onSelect(repo)}
+                onMouseEnter={() => setSelectedIndex(i)}
+                className="w-full flex items-center text-left"
+                style={{
+                  padding: "6px 12px",
+                  gap: 8,
+                  backgroundColor: selected ? "var(--q-bg-hover)" : "transparent",
+                  border: "none",
+                  cursor: "pointer",
+                  fontFamily: font,
+                }}
+              >
+                <span style={{ color: "var(--q-accent)", flexShrink: 0 }}>▸</span>
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: "var(--q-fg)",
+                    minWidth: 0,
+                    flexShrink: 0,
+                    maxWidth: "30%",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {repo.name}
+                </span>
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: "var(--q-fg-secondary)",
+                    flex: 1,
+                    minWidth: 0,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {repo.path}
+                </span>
+                <span
+                  style={{
+                    fontSize: 9,
+                    color: "var(--q-fg-muted)",
+                    flexShrink: 0,
+                  }}
+                >
+                  {relativeTime(repo.closedAt)}
+                </span>
+              </button>
+            );
+          })
+        )}
+        {loading && (
+          <div
+            className="px-3 py-2 text-center"
+            style={{ fontSize: 10, color: "var(--q-fg-muted)" }}
+          >
+            loading...
+          </div>
+        )}
+      </div>
+
+      <button
+        data-testid="open-new-path"
+        onClick={() => {
+          onOpenNewPath();
+        }}
+        onMouseEnter={() => setSelectedIndex(openNewPathIndex)}
+        className="w-full flex items-center text-left"
+        style={{
+          padding: "8px 12px",
+          gap: 8,
+          borderTop: "1px solid var(--q-border)",
+          backgroundColor:
+            selectedIndex === openNewPathIndex ? "var(--q-bg-hover)" : "transparent",
+          border: "none",
+          borderTopWidth: 1,
+          borderTopStyle: "solid",
+          borderTopColor: "var(--q-border)",
+          cursor: "pointer",
+          fontFamily: font,
+          fontSize: 11,
+          color: "var(--q-fg-secondary)",
+        }}
+      >
+        <span style={{ color: "var(--q-accent)" }}>+</span>
+        <span>open new path...</span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { StatusBadge } from "./StatusBadge";
 import { ActionLog } from "./ActionLog";
 import { ContextMenu } from "./ContextMenu";
 import type { MenuItem } from "./ContextMenu";
+import { RecentReposDropdown } from "./RecentReposDropdown";
 import * as api from "../api";
 
 const SIDEBAR_MIN_WIDTH = 200;
@@ -26,6 +27,8 @@ interface SidebarProps {
   onExpandSession: (id: string | null) => void;
   onOpenTab: (id: string) => void;
   onOpenRepo: () => void;
+  onReopenRepo: (repo: Repo) => void;
+  workspaceId: string;
   onCreateTask: (repoId: string) => void;
   onCreateSession: (repoId: string, taskId?: string) => void;
   onRemoveRepo: (repoId: string) => void;
@@ -112,6 +115,8 @@ export function Sidebar({
   onExpandSession,
   onOpenTab,
   onOpenRepo,
+  onReopenRepo,
+  workspaceId,
   onCreateTask,
   onCreateSession,
   onRemoveRepo,
@@ -147,8 +152,23 @@ export function Sidebar({
   const [showArchived, setShowArchived] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT_WIDTH);
+  const [recentReposAnchor, setRecentReposAnchor] = useState<DOMRect | null>(null);
   const isResizing = useRef(false);
   const sidebarRef = useRef<HTMLDivElement>(null);
+
+  const handleOpenRepoButtonClick = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+    setRecentReposAnchor(e.currentTarget.getBoundingClientRect());
+  }, []);
+
+  const handleReopenRecent = useCallback((repo: Repo) => {
+    setRecentReposAnchor(null);
+    onReopenRepo(repo);
+  }, [onReopenRepo]);
+
+  const handleOpenNewPathFromDropdown = useCallback(() => {
+    setRecentReposAnchor(null);
+    onOpenRepo();
+  }, [onOpenRepo]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -510,7 +530,8 @@ export function Sidebar({
             ))}
             <div style={{ width: 24, height: 1, backgroundColor: "var(--q-border)", marginTop: 4, marginBottom: 4 }} />
             <button
-              onClick={onOpenRepo}
+              data-testid="add-repo-button-collapsed"
+              onClick={handleOpenRepoButtonClick}
               className="flex items-center justify-center shrink-0 transition-colors"
               style={{
                 width: 32, height: 32, borderRadius: 4,
@@ -571,6 +592,16 @@ export function Sidebar({
             onClose={() => setContextMenu(null)}
           />
         )}
+
+        {recentReposAnchor && (
+          <RecentReposDropdown
+            workspaceId={workspaceId}
+            anchorRect={recentReposAnchor}
+            onSelect={handleReopenRecent}
+            onOpenNewPath={handleOpenNewPathFromDropdown}
+            onClose={() => setRecentReposAnchor(null)}
+          />
+        )}
       </div>
     );
   }
@@ -603,7 +634,8 @@ export function Sidebar({
           </h1>
           <div className="flex items-center gap-3">
             <button
-              onClick={onOpenRepo}
+              data-testid="add-repo-button"
+              onClick={handleOpenRepoButtonClick}
               className="text-xs lowercase transition-colors"
               style={{ color: "var(--q-fg-secondary)", fontFamily: "'JetBrains Mono', monospace" }}
               onMouseEnter={(e) => (e.currentTarget.style.color = "var(--q-fg)")}
@@ -738,6 +770,16 @@ export function Sidebar({
             y={contextMenu.y}
             items={contextMenu.items}
             onClose={() => setContextMenu(null)}
+          />
+        )}
+
+        {recentReposAnchor && (
+          <RecentReposDropdown
+            workspaceId={workspaceId}
+            anchorRect={recentReposAnchor}
+            onSelect={handleReopenRecent}
+            onOpenNewPath={handleOpenNewPathFromDropdown}
+            onClose={() => setRecentReposAnchor(null)}
           />
         )}
       </aside>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,6 +5,7 @@ export interface Repo {
   workspaceId: string;
   createdAt: string;
   updatedAt: string;
+  closedAt?: string;
 }
 
 export interface Task {

--- a/frontend/wailsjs/go/controller/repoController.d.ts
+++ b/frontend/wailsjs/go/controller/repoController.d.ts
@@ -9,6 +9,8 @@ export function GetRepo(arg1:string):Promise<dto.RepoResponse>;
 
 export function ListReposByWorkspace(arg1:string):Promise<Array<dto.RepoResponse>>;
 
+export function ListClosedReposByWorkspace(arg1:string,arg2:number,arg3:number):Promise<Array<dto.RepoResponse>>;
+
 export function OnShutdown(arg1:context.Context):Promise<void>;
 
 export function OnStartup(arg1:context.Context):Promise<void>;

--- a/frontend/wailsjs/go/controller/repoController.js
+++ b/frontend/wailsjs/go/controller/repoController.js
@@ -14,6 +14,10 @@ export function ListReposByWorkspace(arg1) {
   return window['go']['controller']['repoController']['ListReposByWorkspace'](arg1);
 }
 
+export function ListClosedReposByWorkspace(arg1, arg2, arg3) {
+  return window['go']['controller']['repoController']['ListClosedReposByWorkspace'](arg1, arg2, arg3);
+}
+
 export function OnShutdown(arg1) {
   return window['go']['controller']['repoController']['OnShutdown'](arg1);
 }

--- a/internal/application/adapter/repo_manager.go
+++ b/internal/application/adapter/repo_manager.go
@@ -10,6 +10,7 @@ import (
 type RepoManager interface {
 	OpenRepo(name string, path string, workspaceID string) (*entity.Repo, error)
 	ListReposByWorkspace(workspaceID string) ([]entity.Repo, error)
+	ListClosedReposByWorkspace(workspaceID string, limit int, offset int) ([]entity.Repo, error)
 	GetRepo(id string) (*entity.Repo, error)
 	RemoveRepo(id string) error
 }

--- a/internal/application/service/repo_manager.go
+++ b/internal/application/service/repo_manager.go
@@ -85,6 +85,24 @@ func (s *repoManagerService) ListReposByWorkspace(workspaceID string) ([]entity.
 	return repos, nil
 }
 
+// ListClosedReposByWorkspace returns paginated closed repositories for a workspace,
+// ordered by most recently closed first.
+func (s *repoManagerService) ListClosedReposByWorkspace(workspaceID string, limit int, offset int) ([]entity.Repo, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	repos, err := s.findRepo.FindClosedReposByWorkspace(workspaceID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list closed repos: %w", err)
+	}
+
+	return repos, nil
+}
+
 // GetRepo returns a repository by ID.
 func (s *repoManagerService) GetRepo(id string) (*entity.Repo, error) {
 	repo, err := s.findRepo.FindRepoByID(id)

--- a/internal/application/usecase/find_repo.go
+++ b/internal/application/usecase/find_repo.go
@@ -10,4 +10,5 @@ type FindRepo interface {
 	FindRepoByPathAndWorkspace(path string, workspaceID string) (*entity.Repo, error)
 	FindAllRepos() ([]entity.Repo, error)
 	FindReposByWorkspace(workspaceID string) ([]entity.Repo, error)
+	FindClosedReposByWorkspace(workspaceID string, limit int, offset int) ([]entity.Repo, error)
 }

--- a/internal/integration/adapter/repo_controller.go
+++ b/internal/integration/adapter/repo_controller.go
@@ -14,6 +14,7 @@ type RepoController interface {
 	BrowseDirectory() (string, error)
 	OpenRepo(request dto.CreateRepoRequest) (*dto.RepoResponse, error)
 	ListReposByWorkspace(workspaceID string) ([]dto.RepoResponse, error)
+	ListClosedReposByWorkspace(workspaceID string, limit int, offset int) ([]dto.RepoResponse, error)
 	GetRepo(id string) (*dto.RepoResponse, error)
 	RemoveRepo(id string) error
 	OpenInTerminal(path string) error

--- a/internal/integration/entrypoint/controller/repo.go
+++ b/internal/integration/entrypoint/controller/repo.go
@@ -68,6 +68,17 @@ func (c *repoController) ListReposByWorkspace(workspaceID string) ([]dto.RepoRes
 	return dto.RepoResponseListFromEntities(repos), nil
 }
 
+// ListClosedReposByWorkspace returns paginated closed repositories for a workspace
+// as response DTOs, ordered by most recently closed first.
+func (c *repoController) ListClosedReposByWorkspace(workspaceID string, limit int, offset int) ([]dto.RepoResponse, error) {
+	repos, err := c.repoManager.ListClosedReposByWorkspace(workspaceID, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	return dto.RepoResponseListFromEntities(repos), nil
+}
+
 // GetRepo returns a single repo by ID as a response DTO.
 func (c *repoController) GetRepo(id string) (*dto.RepoResponse, error) {
 	repo, err := c.repoManager.GetRepo(id)

--- a/internal/integration/entrypoint/dto/repo.go
+++ b/internal/integration/entrypoint/dto/repo.go
@@ -20,11 +20,12 @@ type RepoResponse struct {
 	WorkspaceID string `json:"workspaceId"`
 	CreatedAt   string `json:"createdAt"`
 	UpdatedAt   string `json:"updatedAt"`
+	ClosedAt    string `json:"closedAt,omitempty"`
 }
 
 // RepoResponseFromEntity converts a domain entity to a RepoResponse DTO.
 func RepoResponseFromEntity(repo entity.Repo) RepoResponse {
-	return RepoResponse{
+	resp := RepoResponse{
 		ID:          repo.ID,
 		Name:        repo.Name,
 		Path:        repo.Path,
@@ -32,6 +33,10 @@ func RepoResponseFromEntity(repo entity.Repo) RepoResponse {
 		CreatedAt:   repo.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:   repo.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
 	}
+	if repo.ClosedAt != nil {
+		resp.ClosedAt = repo.ClosedAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	return resp
 }
 
 // RepoResponseFromEntityPtr converts a domain entity pointer to a RepoResponse DTO pointer.

--- a/internal/integration/persistence/repo.go
+++ b/internal/integration/persistence/repo.go
@@ -93,6 +93,33 @@ func (p *repoPersistence) FindAllRepos() ([]entity.Repo, error) {
 	return repos, nil
 }
 
+// FindClosedReposByWorkspace retrieves closed repos for a specific workspace,
+// ordered by most recently closed first, with pagination.
+func (p *repoPersistence) FindClosedReposByWorkspace(workspaceID string, limit int, offset int) ([]entity.Repo, error) {
+	query := `SELECT ` + repoColumns + ` FROM repos WHERE closed_at IS NOT NULL AND workspace_id = ? ORDER BY closed_at DESC LIMIT ? OFFSET ?`
+
+	rows, err := p.db.Query(query, workspaceID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find closed repos by workspace: %w", err)
+	}
+	defer rows.Close()
+
+	var repos []entity.Repo
+	for rows.Next() {
+		row, err := scanRepoRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan repo row: %w", err)
+		}
+		repos = append(repos, row.ToEntity())
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating repo rows: %w", err)
+	}
+
+	return repos, nil
+}
+
 // FindReposByWorkspace retrieves all open repos for a specific workspace.
 func (p *repoPersistence) FindReposByWorkspace(workspaceID string) ([]entity.Repo, error) {
 	query := `SELECT ` + repoColumns + ` FROM repos WHERE closed_at IS NULL AND workspace_id = ? ORDER BY created_at DESC`


### PR DESCRIPTION
## Summary

- New `RecentReposDropdown` component anchored to the `+ repo` sidebar button: shows previously-closed repos for the current workspace (sorted by most recently closed), supports type-to-filter on name/path, infinite scroll (20 at a time), and ↑/↓/Enter/Esc keyboard nav. Picking a recent repo reopens it via the existing `OpenRepo` service (no modal, no path typing). The bottom `+ open new path...` action falls through to the existing `OpenRepoModal`. Workspaces with zero closed repos skip the dropdown and open the modal directly.
- Backend: added `FindClosedReposByWorkspace` (persistence) → `ListClosedReposByWorkspace` (service) → wails-bound controller method (`internal/integration/entrypoint/controller/repo.go`). `RepoResponse` DTO now exposes `closedAt` so the dropdown can render relative timestamps.
- Closes #49.

## Test plan

- [x] Click `+ repo` shows dropdown with closed repos sorted by `closedAt DESC`
- [x] Selecting a repo reopens it (verified `OpenRepo({name, path, workspaceId})` fires; reopened repo no longer in closed list)
- [x] Type-to-filter narrows by name (`poco` → 1 result) and by path (`work` → 2 results matching paths/names)
- [x] Infinite scroll — 50 closed repos fetched in 3 paginated calls (offsets 0/20/40, returning 20/20/10)
- [x] `+ open new path...` action opens `OpenRepoModal` and dropdown closes
- [x] Keyboard: ↑/↓ moves highlight, Enter opens highlighted repo, Esc closes dropdown
- [x] Empty state (workspace has no closed repos) skips dropdown, opens `OpenRepoModal` directly
- [x] `go vet ./internal/...` clean
- [x] `tsc --noEmit` clean
- [ ] Manual smoke test inside Wails dev runtime (not possible from this branch — Playwright was run against Vite with stubbed `window.go`; verify in `wails dev` before merge)

Test report posted on issue #49 with screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)