### PR TITLE
fix(issue-52): prevent workspace-switch UI freeze during active sessions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -337,20 +337,29 @@ function App() {
       prevWorkspaceId.current = activeWorkspaceId;
     }
 
-    // Reload repos (which are workspace-scoped) when workspace changes
-    (async () => {
-      const repoList = await fetchRepos(activeWorkspaceId);
-      for (const repo of repoList) {
-        const tasks = await fetchTasksForRepo(repo.id);
-        await fetchSessionsForRepo(repo.id);
-        for (const task of tasks) {
-          await fetchSessionsForTask(task.id);
-        }
-      }
-    })();
-    fetchJobs();
-    fetchAgents();
-    fetchJobGroups();
+    // Reload workspace-scoped data after letting React paint the tab swap
+    // first. Doing this synchronously after setOpenTabIds caused a long
+    // render storm (every fetch resolved with a setState) on top of the
+    // TerminalPane remount, freezing the UI when a session was actively
+    // streaming output. We yield one task, then fan out in parallel.
+    const handle = setTimeout(() => {
+      (async () => {
+        const repoList = await fetchRepos(activeWorkspaceId);
+        await Promise.all(
+          repoList.map(async (repo) => {
+            const [tasks] = await Promise.all([
+              fetchTasksForRepo(repo.id),
+              fetchSessionsForRepo(repo.id),
+            ]);
+            await Promise.all(tasks.map((task) => fetchSessionsForTask(task.id)));
+          })
+        );
+      })().catch((err) => console.error("failed to reload workspace data:", err));
+      fetchJobs();
+      fetchAgents();
+      fetchJobGroups();
+    }, 0);
+    return () => clearTimeout(handle);
   }, [activeWorkspaceId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Persist open tabs and active tab to config whenever they change

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -153,18 +153,78 @@ export function TerminalPane({
 
     startedRef.current = false;
 
+    // Tracks whether this effect instance is still mounted. Async callbacks
+    // (getSessionOutput, EventsOn) check this before writing so they don't
+    // touch a disposed terminal after a workspace switch / remount.
+    const alive = { current: true };
+
+    // Chunked replay state. While the initial buffer is being written we queue
+    // any live `session:output` payloads here and flush them in order after
+    // replay completes. This avoids the double-write storm where multi-megabyte
+    // replay blocks the renderer and concurrent live events stack on top.
+    const replayState = { replaying: false };
+    const liveQueue: string[] = [];
+
+    const writeChunked = (full: string, onDone?: () => void) => {
+      if (!alive.current || !termRef.current) return;
+      const chunkSize = 64 * 1024;
+      let offset = 0;
+      replayState.replaying = true;
+      isWritingRef.current = true;
+
+      const writeNext = () => {
+        if (!alive.current || !termRef.current) {
+          replayState.replaying = false;
+          isWritingRef.current = false;
+          return;
+        }
+        if (offset >= full.length) {
+          replayState.replaying = false;
+          if (autoScrollRef.current && termRef.current) {
+            termRef.current.scrollToBottom();
+          }
+          // Drain any live events that arrived during replay.
+          const queued = liveQueue.splice(0, liveQueue.length);
+          if (queued.length > 0 && termRef.current) {
+            termRef.current.write(queued.join(""), () => {
+              if (autoScrollRef.current && termRef.current) {
+                termRef.current.scrollToBottom();
+              }
+              isWritingRef.current = false;
+              onDone?.();
+            });
+          } else {
+            isWritingRef.current = false;
+            onDone?.();
+          }
+          return;
+        }
+        const piece = full.slice(offset, offset + chunkSize);
+        offset += chunkSize;
+        termRef.current.write(piece, () => {
+          // Yield to the browser between chunks so the UI stays responsive.
+          requestAnimationFrame(writeNext);
+        });
+      };
+
+      writeNext();
+    };
+
     if (isArchived) {
       api
         .getSessionOutput(session.id)
         .then((output) => {
-          if (output && termRef.current) {
-            termRef.current.write(output);
-            termRef.current.write("\r\n\x1b[33m// archived session (read-only)\x1b[0m\r\n");
-          }
+          if (!alive.current || !output || !termRef.current) return;
+          writeChunked(output, () => {
+            if (alive.current && termRef.current) {
+              termRef.current.write("\r\n\x1b[33m// archived session (read-only)\x1b[0m\r\n");
+            }
+          });
         })
         .catch(() => {});
 
       return () => {
+        alive.current = false;
         if (termRef.current) {
           termRef.current.dispose();
           termRef.current = null;
@@ -179,22 +239,29 @@ export function TerminalPane({
     const cancelOutput = w.runtime.EventsOn(
       "session:output",
       (data: { sessionId: string; data: string }) => {
-        if (data.sessionId === session.id && termRef.current) {
-          isWritingRef.current = true;
-          termRef.current.write(data.data, () => {
-            if (autoScrollRef.current && termRef.current) {
-              termRef.current.scrollToBottom();
-            }
-            isWritingRef.current = false;
-          });
+        if (!alive.current || data.sessionId !== session.id || !termRef.current) {
+          return;
         }
+        if (replayState.replaying) {
+          // Hold live events until the initial buffer finishes writing.
+          liveQueue.push(data.data);
+          return;
+        }
+        isWritingRef.current = true;
+        termRef.current.write(data.data, () => {
+          if (!alive.current) return;
+          if (autoScrollRef.current && termRef.current) {
+            termRef.current.scrollToBottom();
+          }
+          isWritingRef.current = false;
+        });
       }
     );
 
     const cancelExited = w.runtime.EventsOn(
       "session:exited",
       (data: { sessionId: string }) => {
-        if (data.sessionId === session.id && termRef.current) {
+        if (alive.current && data.sessionId === session.id && termRef.current) {
           termRef.current.write("\r\n\x1b[90m// session exited\x1b[0m\r\n");
         }
       }
@@ -204,15 +271,8 @@ export function TerminalPane({
       api
         .getSessionOutput(session.id)
         .then((output) => {
-          if (output && termRef.current) {
-            isWritingRef.current = true;
-            termRef.current.write(output, () => {
-              if (autoScrollRef.current && termRef.current) {
-                termRef.current.scrollToBottom();
-              }
-              isWritingRef.current = false;
-            });
-          }
+          if (!alive.current || !output || !termRef.current) return;
+          writeChunked(output);
         })
         .catch(() => {});
     }
@@ -231,6 +291,7 @@ export function TerminalPane({
         }
       }, 100);
       return () => {
+        alive.current = false;
         clearTimeout(timer);
         if (cancelOutput) cancelOutput();
         if (cancelExited) cancelExited();
@@ -242,6 +303,7 @@ export function TerminalPane({
     }
 
     return () => {
+      alive.current = false;
       if (cancelOutput) cancelOutput();
       if (cancelExited) cancelExited();
       if (termRef.current) {

--- a/internal/integration/process/manager.go
+++ b/internal/integration/process/manager.go
@@ -394,14 +394,57 @@ func (m *processManager) Resize(sessionID string, rows uint16, cols uint16) erro
 	return pty.Setsize(cp.ptm, &pty.Winsize{Rows: rows, Cols: cols})
 }
 
-// GetOutput returns the persisted output for a session from disk.
+// maxReplayBytes caps the size of the session output replay returned to the
+// frontend on terminal remount. Larger histories are truncated to the tail so
+// that mounting a TerminalPane never blocks the renderer with a multi-megabyte
+// xterm write. The visible terminal scrollback still grows beyond this via
+// live "session:output" events.
+const maxReplayBytes int64 = 256 * 1024
+
+// GetOutput returns the persisted output for a session from disk. The result
+// is capped at the last maxReplayBytes bytes; if the file is larger, a short
+// grey notice is prepended so the user knows earlier output was elided.
 func (m *processManager) GetOutput(sessionID string) ([]byte, error) {
-	data, err := os.ReadFile(m.outputPath(sessionID))
+	path := m.outputPath(sessionID)
+	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return []byte{}, nil
 		}
-		return nil, fmt.Errorf("failed to read output file: %w", err)
+		return nil, fmt.Errorf("failed to open output file: %w", err)
 	}
-	return data, nil
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat output file: %w", err)
+	}
+
+	size := info.Size()
+	if size <= maxReplayBytes {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read output file: %w", err)
+		}
+		return data, nil
+	}
+
+	tail := make([]byte, maxReplayBytes)
+	if _, err := f.ReadAt(tail, size-maxReplayBytes); err != nil {
+		return nil, fmt.Errorf("failed to read output tail: %w", err)
+	}
+
+	// Advance to the next valid utf8 start so we don't slice through a multi-byte
+	// rune. Worst case we drop up to 3 bytes, which is acceptable.
+	start := 0
+	for start < len(tail) && start < 4 && !utf8.RuneStart(tail[start]) {
+		start++
+	}
+	tail = tail[start:]
+
+	notice := []byte("\x1b[90m// [earlier output truncated]\x1b[0m\r\n")
+	out := make([]byte, 0, len(notice)+len(tail))
+	out = append(out, notice...)
+	out = append(out, tail...)
+	return out, nil
 }


### PR DESCRIPTION
## Summary
- Stops the hard freeze on workspace switch (issue #52) by attacking the three hot paths that combined to stall the renderer.
- Cap the initial buffer replay at the last 256 KB on the backend, chunk + frame-yield the xterm write on the frontend, and queue concurrent live events so they flush in order after replay.
- Defer the workspace-switch fetch chain off the render path and fan it out with `Promise.all` instead of serial `for-await`.

## Changes
- `internal/integration/process/manager.go` — `GetOutput` now reads only the tail of the session output file (utf8-safe) with an `[earlier output truncated]` notice when elided.
- `frontend/src/components/TerminalPane.tsx` — chunked replay via `requestAnimationFrame`, live `session:output` events queued during replay and flushed after, `alive` guard on every async callback so disposed terminals are never written to.
- `frontend/src/App.tsx` — workspace-switch effect defers data reload by one task, fans out repo / task / session fetches with `Promise.all`, and cancels pending work if the workspace changes again.

## Test plan
- [ ] Open a session, kick off something chatty (long build / chatty Claude run), switch workspaces and back — UI stays responsive, terminal restores in under 500 ms with brief catching-up before flushing live events.
- [ ] Toggle workspaces rapidly during heavy output — no console errors from stale-handler writes.
- [ ] Confirm large/old sessions show the `[earlier output truncated]` notice on remount.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)