### PR TITLE
feat(issue-50): typed job input/output contracts on the workflow engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: release release-patch release-minor release-major dev build
+.PHONY: release release-patch release-minor release-major dev build test
 
 # Auto-bump: make release-patch | release-minor | release-major
 # Manual:    make release v=1.0.0
@@ -48,3 +48,9 @@ install:
 update:
 	brew update
 	brew upgrade quant
+
+# Run Go tests with the race detector. issue #50 unit tests for the typed
+# input validator and <quant-output> sentinel extractor live in
+# internal/application/service/*_test.go.
+test:
+	go test -race ./...

--- a/frontend/src/components/SchemaFieldEditor.tsx
+++ b/frontend/src/components/SchemaFieldEditor.tsx
@@ -1,0 +1,209 @@
+import React, { useState } from "react";
+import type { SchemaField } from "../types";
+
+const TYPES = ["string", "number", "boolean", "object", "array"] as const;
+const SOURCES = ["passthrough", "produced"] as const;
+const font = "'JetBrains Mono', monospace";
+
+interface Props {
+  kind: "input" | "output";
+  fields: SchemaField[];
+  onChange: (next: SchemaField[]) => void;
+}
+
+/**
+ * SchemaFieldEditor — per-row editor for the `inputs` or `outputs` array on
+ * a Job. Modelled after the Shortcuts editor in Settings.tsx; uses the same
+ * JetBrains Mono / lowercase aesthetic and css vars.
+ *
+ * For `kind="input"` the row shows: key | type | required toggle | x
+ * For `kind="output"` the row shows: key | type | source select   | x
+ *
+ * issue #50: typed metadata pipeline contract editor.
+ */
+export function SchemaFieldEditor({ kind, fields, onChange }: Props) {
+  const [newKey, setNewKey] = useState("");
+
+  function updateRow(index: number, patch: Partial<SchemaField>) {
+    onChange(fields.map((f, i) => (i === index ? { ...f, ...patch } : f)));
+  }
+
+  function removeRow(index: number) {
+    onChange(fields.filter((_, i) => i !== index));
+  }
+
+  function addRow() {
+    const key = newKey.trim();
+    if (!key) return;
+    const blank: SchemaField =
+      kind === "input"
+        ? { key, type: "string", required: false }
+        : { key, type: "string", source: "passthrough" };
+    onChange([...fields, blank]);
+    setNewKey("");
+  }
+
+  const inputStyle: React.CSSProperties = {
+    backgroundColor: "var(--q-bg-hover)",
+    border: "1px solid var(--q-border)",
+    color: "var(--q-fg)",
+    fontSize: 11,
+    fontFamily: font,
+    padding: "4px 8px",
+    outline: "none",
+  };
+
+  const selectStyle: React.CSSProperties = {
+    ...inputStyle,
+    color: "var(--q-accent)",
+    cursor: "pointer",
+  };
+
+  return (
+    <div
+      data-testid={`schema-editor-${kind}`}
+      style={{ display: "flex", flexDirection: "column", gap: 6 }}
+    >
+      {fields.length === 0 && (
+        <div
+          style={{
+            color: "var(--q-fg-muted)",
+            fontSize: 10,
+            fontFamily: font,
+          }}
+        >
+          // no {kind === "input" ? "inputs" : "outputs"} declared
+        </div>
+      )}
+
+      {fields.map((f, i) => (
+        <div
+          key={i}
+          data-testid={`schema-field-row-${i}`}
+          className="flex items-center"
+          style={{ gap: 6 }}
+        >
+          <input
+            data-testid={`schema-field-key-${i}`}
+            value={f.key}
+            onChange={(e) => updateRow(i, { key: e.target.value })}
+            placeholder="key"
+            style={{ ...inputStyle, flex: 1, minWidth: 0 }}
+            onFocus={(e) => (e.currentTarget.style.borderColor = "var(--q-accent)")}
+            onBlur={(e) => (e.currentTarget.style.borderColor = "var(--q-border)")}
+          />
+          <select
+            data-testid={`schema-field-type-${i}`}
+            value={f.type || "string"}
+            onChange={(e) => updateRow(i, { type: e.target.value })}
+            style={{ ...selectStyle, width: 100 }}
+          >
+            {TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+
+          {kind === "input" && (
+            <label
+              data-testid={`schema-field-required-${i}`}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 4,
+                fontFamily: font,
+                fontSize: 11,
+                color: "var(--q-fg-secondary)",
+                cursor: "pointer",
+                userSelect: "none",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={!!f.required}
+                onChange={(e) => updateRow(i, { required: e.target.checked })}
+              />
+              required
+            </label>
+          )}
+
+          {kind === "output" && (
+            <select
+              data-testid={`schema-field-source-${i}`}
+              value={f.source || "passthrough"}
+              onChange={(e) => updateRow(i, { source: e.target.value })}
+              style={{ ...selectStyle, width: 120 }}
+            >
+              {SOURCES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          )}
+
+          <button
+            type="button"
+            data-testid={`schema-field-delete-${i}`}
+            onClick={() => removeRow(i)}
+            style={{
+              color: "var(--q-error)",
+              fontSize: 11,
+              fontFamily: font,
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              padding: "0 6px",
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.opacity = "0.7")}
+            onMouseLeave={(e) => (e.currentTarget.style.opacity = "1")}
+          >
+            x
+          </button>
+        </div>
+      ))}
+
+      <div
+        className="flex items-center"
+        style={{ gap: 6, marginTop: fields.length > 0 ? 4 : 0 }}
+      >
+        <input
+          data-testid={`schema-field-new-key-${kind}`}
+          value={newKey}
+          onChange={(e) => setNewKey(e.target.value)}
+          placeholder="key"
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              addRow();
+            }
+          }}
+          style={{ ...inputStyle, flex: 1, minWidth: 0 }}
+          onFocus={(e) => (e.currentTarget.style.borderColor = "var(--q-accent)")}
+          onBlur={(e) => (e.currentTarget.style.borderColor = "var(--q-border)")}
+        />
+        <button
+          type="button"
+          data-testid={`schema-field-add-${kind}`}
+          onClick={addRow}
+          style={{
+            color: "var(--q-fg-muted)",
+            fontSize: 11,
+            fontFamily: font,
+            border: "1px dashed var(--q-border)",
+            padding: "4px 10px",
+            background: "none",
+            cursor: "pointer",
+          }}
+          onMouseEnter={(e) =>
+            (e.currentTarget.style.color = "var(--q-fg-secondary)")
+          }
+          onMouseLeave={(e) => (e.currentTarget.style.color = "var(--q-fg-muted)")}
+        >
+          + add field
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -117,12 +117,28 @@ export interface Job {
   interpreter: string;
   scriptContent: string;
   envVariables: Record<string, string>;
+  // issue #50: typed metadata contract.
+  inputs: JobInputSpec[];
+  outputs: JobOutputSpec[];
   onSuccess: string[];
   onFailure: string[];
   triggeredBy: TriggerRef[];
   workspaceId: string;
   createdAt: string;
   updatedAt: string;
+}
+
+// issue #50: typed metadata contract specs (mirror entity.JobInputSpec / JobOutputSpec).
+export interface JobInputSpec {
+  key: string;
+  type: "string" | "number" | "boolean" | "object" | "array";
+  required: boolean;
+}
+
+export interface JobOutputSpec {
+  key: string;
+  type: "string" | "number" | "boolean" | "object" | "array";
+  source: "produced" | "passthrough";
 }
 
 export interface TriggerRef {
@@ -155,6 +171,9 @@ export interface CreateJobRequest {
   interpreter: string;
   scriptContent: string;
   envVariables: Record<string, string>;
+  // issue #50: typed metadata contract.
+  inputs?: JobInputSpec[];
+  outputs?: JobOutputSpec[];
   onSuccess: string[];
   onFailure: string[];
   workspaceId?: string;
@@ -177,6 +196,9 @@ export interface JobRun {
   result: string;
   errorMessage: string;
   injectedContext: string;
+  // issue #50: produced typed metadata + validation surface.
+  metadata?: Record<string, unknown>;
+  validationError?: string;
   startedAt: string;
   finishedAt: string;
 }

--- a/frontend/wailsjs/go/controller/repoController.d.ts
+++ b/frontend/wailsjs/go/controller/repoController.d.ts
@@ -7,9 +7,9 @@ export function BrowseDirectory():Promise<string>;
 
 export function GetRepo(arg1:string):Promise<dto.RepoResponse>;
 
-export function ListReposByWorkspace(arg1:string):Promise<Array<dto.RepoResponse>>;
-
 export function ListClosedReposByWorkspace(arg1:string,arg2:number,arg3:number):Promise<Array<dto.RepoResponse>>;
+
+export function ListReposByWorkspace(arg1:string):Promise<Array<dto.RepoResponse>>;
 
 export function OnShutdown(arg1:context.Context):Promise<void>;
 

--- a/frontend/wailsjs/go/controller/repoController.js
+++ b/frontend/wailsjs/go/controller/repoController.js
@@ -10,12 +10,12 @@ export function GetRepo(arg1) {
   return window['go']['controller']['repoController']['GetRepo'](arg1);
 }
 
-export function ListReposByWorkspace(arg1) {
-  return window['go']['controller']['repoController']['ListReposByWorkspace'](arg1);
-}
-
 export function ListClosedReposByWorkspace(arg1, arg2, arg3) {
   return window['go']['controller']['repoController']['ListClosedReposByWorkspace'](arg1, arg2, arg3);
+}
+
+export function ListReposByWorkspace(arg1) {
+  return window['go']['controller']['repoController']['ListReposByWorkspace'](arg1);
 }
 
 export function OnShutdown(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -571,6 +571,7 @@ export namespace dto {
 	    workspaceId: string;
 	    createdAt: string;
 	    updatedAt: string;
+	    closedAt?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new RepoResponse(source);
@@ -584,6 +585,7 @@ export namespace dto {
 	        this.workspaceId = source["workspaceId"];
 	        this.createdAt = source["createdAt"];
 	        this.updatedAt = source["updatedAt"];
+	        this.closedAt = source["closedAt"];
 	    }
 	}
 	export class SaveConfigRequest {

--- a/internal/application/adapter/job_manager.go
+++ b/internal/application/adapter/job_manager.go
@@ -12,7 +12,16 @@ type JobManager interface {
 	GetJob(id string) (*entity.Job, error)
 	ListJobs() ([]entity.Job, error)
 	GetTriggersForJob(jobID string) (onSuccess []entity.JobTrigger, onFailure []entity.JobTrigger, triggeredBy []entity.JobTrigger, err error)
-	RunJob(jobID string, triggeredByRunID string, correlationID ...string) (*entity.JobRun, error)
+	// RunJob starts a new run.
+	//   - inputs: typed metadata for the run's pre-run validation gate. For a
+	//     ROOT run (triggeredByRunID == "") this becomes the run's initial
+	//     Metadata (the "inbound" the gate validates against). For a TRIGGERED
+	//     run the gate ignores inputs and reads the parent run's Metadata
+	//     instead — fireTriggers passes the parent's typed metadata through
+	//     upstream's existing trigger/injected_context plumbing, so passing
+	//     nil here is the right default for trigger-paths.
+	//   - correlationID: upstream's pipeline-wide id (variadic, optional).
+	RunJob(jobID string, triggeredByRunID string, inputs map[string]any, correlationID ...string) (*entity.JobRun, error)
 	RunJobWithContext(jobID string, context string) (*entity.JobRun, error)
 	RerunJob(jobID string, originalRunID string) (*entity.JobRun, error)
 	CancelRun(runID string) error

--- a/internal/application/service/input_validator.go
+++ b/internal/application/service/input_validator.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"quant/internal/domain/entity"
+)
+
+// ValidationError captures pre-run validation failures as a structured object
+// so the frontend can render it nicely. The .Error() form is what gets stored
+// in run.ValidationError for machine-readable diagnostics.
+type ValidationError struct {
+	MissingKeys []string          // required keys absent from inbound
+	WrongTypes  map[string]string // key -> "expected <T>, got <U>"
+}
+
+// Error renders a deterministic, human-readable summary of the failures.
+func (e *ValidationError) Error() string {
+	parts := []string{}
+	if len(e.MissingKeys) > 0 {
+		sorted := append([]string(nil), e.MissingKeys...)
+		sort.Strings(sorted)
+		parts = append(parts, "missing required input "+formatKeyList(sorted))
+	}
+	if len(e.WrongTypes) > 0 {
+		keys := make([]string, 0, len(e.WrongTypes))
+		for k := range e.WrongTypes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			parts = append(parts, fmt.Sprintf("input %q: %s", k, e.WrongTypes[k]))
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+func formatKeyList(keys []string) string {
+	quoted := make([]string, len(keys))
+	for i, k := range keys {
+		quoted[i] = fmt.Sprintf("%q", k)
+	}
+	return strings.Join(quoted, ", ")
+}
+
+// validateInputs checks an inbound metadata map against a job's declared
+// input specs. Returns nil when valid; *ValidationError otherwise.
+//
+// Rules:
+//   - spec.Required and key absent  -> MissingKeys
+//   - key present but type mismatch -> WrongTypes
+//   - key absent and not required   -> ignored
+//   - extra keys not declared       -> ignored (open-world model)
+func validateInputs(specs []entity.JobInputSpec, inbound map[string]any) error {
+	if len(specs) == 0 {
+		return nil
+	}
+	if inbound == nil {
+		inbound = map[string]any{}
+	}
+	verr := &ValidationError{WrongTypes: map[string]string{}}
+	for _, spec := range specs {
+		v, present := inbound[spec.Key]
+		if !present {
+			if spec.Required {
+				verr.MissingKeys = append(verr.MissingKeys, spec.Key)
+			}
+			continue
+		}
+		if !typeMatches(spec.Type, v) {
+			verr.WrongTypes[spec.Key] = fmt.Sprintf("expected %s, got %s", spec.Type, jsonTypeOf(v))
+		}
+	}
+	if len(verr.MissingKeys) == 0 && len(verr.WrongTypes) == 0 {
+		return nil
+	}
+	return verr
+}
+
+// typeMatches reports whether v satisfies the declared spec type.
+// Spec types: "string"|"number"|"boolean"|"object"|"array".
+// "" or "any" matches anything (escape hatch for legacy/loose specs).
+func typeMatches(declared string, v any) bool {
+	switch declared {
+	case "", "any":
+		return true
+	case "string":
+		_, ok := v.(string)
+		return ok
+	case "number":
+		switch v.(type) {
+		case float64, float32, int, int32, int64, uint, uint32, uint64:
+			return true
+		}
+		return false
+	case "boolean":
+		_, ok := v.(bool)
+		return ok
+	case "object":
+		_, ok := v.(map[string]any)
+		return ok
+	case "array":
+		_, ok := v.([]any)
+		return ok
+	}
+	return false
+}
+
+// jsonTypeOf returns the JSON-style type name of a Go value, for diagnostics.
+func jsonTypeOf(v any) string {
+	switch v.(type) {
+	case nil:
+		return "null"
+	case string:
+		return "string"
+	case bool:
+		return "boolean"
+	case float64, float32, int, int32, int64, uint, uint32, uint64:
+		return "number"
+	case map[string]any:
+		return "object"
+	case []any:
+		return "array"
+	default:
+		return fmt.Sprintf("%T", v)
+	}
+}

--- a/internal/application/service/input_validator_test.go
+++ b/internal/application/service/input_validator_test.go
@@ -1,0 +1,168 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"quant/internal/domain/entity"
+)
+
+// TestValidateInputs_EmptySpecs verifies the spec==0 short-circuit returns nil.
+func TestValidateInputs_EmptySpecs(t *testing.T) {
+	if err := validateInputs(nil, nil); err != nil {
+		t.Errorf("nil specs + nil inbound: want nil err, got %v", err)
+	}
+	if err := validateInputs([]entity.JobInputSpec{}, map[string]any{"x": 1}); err != nil {
+		t.Errorf("empty specs + non-nil inbound: want nil err, got %v", err)
+	}
+}
+
+// TestValidateInputs covers presence, type-matching, and the "all five types"
+// table required by acceptance.
+func TestValidateInputs(t *testing.T) {
+	cases := []struct {
+		name      string
+		specs     []entity.JobInputSpec
+		inbound   map[string]any
+		wantErr   bool
+		wantInErr []string // substrings expected when wantErr is true
+	}{
+		{
+			name: "all-required-present-valid",
+			specs: []entity.JobInputSpec{
+				{Key: "linearId", Type: "string", Required: true},
+				{Key: "count", Type: "number", Required: true},
+			},
+			inbound: map[string]any{"linearId": "MAX-86", "count": 1.0},
+			wantErr: false,
+		},
+		{
+			name: "missing-required-names-key",
+			specs: []entity.JobInputSpec{
+				{Key: "linearId", Type: "string", Required: true},
+				{Key: "count", Type: "number", Required: false},
+			},
+			inbound:   map[string]any{"count": 1.0},
+			wantErr:   true,
+			wantInErr: []string{"linearId", "missing"},
+		},
+		{
+			name: "wrong-type-string-vs-number",
+			specs: []entity.JobInputSpec{
+				{Key: "linearId", Type: "string", Required: true},
+			},
+			inbound:   map[string]any{"linearId": 42},
+			wantErr:   true,
+			wantInErr: []string{"linearId", "expected string", "got number"},
+		},
+		{
+			name: "wrong-type-object-vs-array",
+			specs: []entity.JobInputSpec{
+				{Key: "tags", Type: "array", Required: true},
+			},
+			inbound:   map[string]any{"tags": map[string]any{"a": 1}},
+			wantErr:   true,
+			wantInErr: []string{"tags", "expected array", "got object"},
+		},
+		{
+			name: "optional-missing-ok",
+			specs: []entity.JobInputSpec{
+				{Key: "linearId", Type: "string", Required: true},
+				{Key: "tag", Type: "string", Required: false},
+			},
+			inbound: map[string]any{"linearId": "x"},
+			wantErr: false,
+		},
+		{
+			name: "nil-inbound-but-required",
+			specs: []entity.JobInputSpec{
+				{Key: "linearId", Type: "string", Required: true},
+			},
+			inbound:   nil,
+			wantErr:   true,
+			wantInErr: []string{"linearId"},
+		},
+		{
+			name: "extra-keys-ignored",
+			specs: []entity.JobInputSpec{
+				{Key: "linearId", Type: "string", Required: true},
+			},
+			inbound: map[string]any{"linearId": "x", "rogue": "ok", "more": 5.0},
+			wantErr: false,
+		},
+		// All five recognised types: string, number, boolean, object, array.
+		{
+			name: "all-five-types-match",
+			specs: []entity.JobInputSpec{
+				{Key: "s", Type: "string", Required: true},
+				{Key: "n", Type: "number", Required: true},
+				{Key: "b", Type: "boolean", Required: true},
+				{Key: "o", Type: "object", Required: true},
+				{Key: "a", Type: "array", Required: true},
+			},
+			inbound: map[string]any{
+				"s": "hi",
+				"n": 3.14,
+				"b": true,
+				"o": map[string]any{"k": "v"},
+				"a": []any{1.0, 2.0},
+			},
+			wantErr: false,
+		},
+		{
+			name: "boolean-wrong-type",
+			specs: []entity.JobInputSpec{
+				{Key: "flag", Type: "boolean", Required: true},
+			},
+			inbound:   map[string]any{"flag": "true"},
+			wantErr:   true,
+			wantInErr: []string{"flag", "expected boolean", "got string"},
+		},
+		{
+			name: "object-wrong-type",
+			specs: []entity.JobInputSpec{
+				{Key: "obj", Type: "object", Required: true},
+			},
+			inbound:   map[string]any{"obj": []any{1.0}},
+			wantErr:   true,
+			wantInErr: []string{"obj", "expected object", "got array"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateInputs(tc.specs, tc.inbound)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v, got err=%v", tc.wantErr, err)
+			}
+			if err != nil {
+				msg := err.Error()
+				for _, want := range tc.wantInErr {
+					if !strings.Contains(msg, want) {
+						t.Errorf("err %q missing substring %q", msg, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestValidateInputs_MultipleErrorsCombined ensures both classes of error
+// surface together for a single call.
+func TestValidateInputs_MultipleErrorsCombined(t *testing.T) {
+	specs := []entity.JobInputSpec{
+		{Key: "a", Type: "string", Required: true},
+		{Key: "b", Type: "number", Required: true},
+	}
+	err := validateInputs(specs, map[string]any{"b": "not-a-number"})
+	if err == nil {
+		t.Fatalf("expected combined error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "missing") || !strings.Contains(msg, "\"a\"") {
+		t.Errorf("missing 'a' not in %q", msg)
+	}
+	if !strings.Contains(msg, "\"b\"") || !strings.Contains(msg, "expected number") {
+		t.Errorf("type error for 'b' not in %q", msg)
+	}
+}

--- a/internal/application/service/job_manager.go
+++ b/internal/application/service/job_manager.go
@@ -224,7 +224,7 @@ func (s *jobManagerService) GetTriggersForJob(jobID string) (onSuccess []entity.
 }
 
 // RunJob starts a new run for a job. Supports retries with history for Claude jobs.
-func (s *jobManagerService) RunJob(jobID string, triggeredByRunID string, correlationID ...string) (*entity.JobRun, error) {
+func (s *jobManagerService) RunJob(jobID string, triggeredByRunID string, inputs map[string]any, correlationID ...string) (*entity.JobRun, error) {
 	job, err := s.findJob.FindJobByID(jobID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find job: %w", err)
@@ -240,6 +240,20 @@ func (s *jobManagerService) RunJob(jobID string, triggeredByRunID string, correl
 		Status:      jobrunstatus.Running,
 		TriggeredBy: triggeredByRunID,
 		StartedAt:   now,
+	}
+
+	// issue #50: typed metadata pipeline.
+	//   - ROOT run (no triggering parent): inputs ARE the initial inbound the
+	//     pre-run gate will validate against, so we pre-seed run.Metadata
+	//     with them. After execution, finalizeMetadata overwrites Metadata
+	//     with the produced outputs.
+	//   - TRIGGERED run: the gate looks up the parent's Metadata via
+	//     TriggeredBy; we don't pre-seed (inputs is expected to be nil here).
+	if triggeredByRunID == "" && len(inputs) > 0 {
+		run.Metadata = make(map[string]any, len(inputs))
+		for k, v := range inputs {
+			run.Metadata[k] = v
+		}
 	}
 
 	if len(correlationID) > 0 && correlationID[0] != "" {
@@ -285,24 +299,32 @@ func (s *jobManagerService) RunJob(jobID string, triggeredByRunID string, correl
 		}
 	}
 
-	// Execute asynchronously
+	// Execute asynchronously.
+	//
+	// The async goroutine mutates the run (status, metadata, validation error,
+	// finishedAt, ...). To avoid a data race with the synchronous caller — which
+	// serialises the returned run object immediately (e.g. the MCP run_job
+	// handler) — the goroutine operates on its OWN copy and we return a separate
+	// snapshot. All durable state flows through the DB, so the copies never
+	// diverge in a way that matters.
+	asyncRun := run
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
 				// Write panic info to run log so we can diagnose
-				logPath := runLogPath(run.ID)
+				logPath := runLogPath(asyncRun.ID)
 				if f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
 					fmt.Fprintf(f, "\n\n--- PANIC ---\n%v\n", r)
 					f.Close()
 				}
 				now := time.Now()
-				run.Status = jobrunstatus.Failed
-				run.ErrorMessage = fmt.Sprintf("panic: %v", r)
-				run.FinishedAt = &now
-				_ = s.saveJobRun.UpdateJobRun(run)
+				asyncRun.Status = jobrunstatus.Failed
+				asyncRun.ErrorMessage = fmt.Sprintf("panic: %v", r)
+				asyncRun.FinishedAt = &now
+				_ = s.saveJobRun.UpdateJobRun(asyncRun)
 			}
 		}()
-		s.executeWithRetries(job, &run, csKey)
+		s.executeWithRetries(job, &asyncRun, csKey)
 	}()
 
 	return &run, nil
@@ -312,7 +334,7 @@ func (s *jobManagerService) RunJob(jobID string, triggeredByRunID string, correl
 // The context string is prepended to the job's prompt in the same format as trigger context,
 // so existing jobs that parse TASK_IDENTIFIER= etc. work without modification.
 func (s *jobManagerService) RunJobWithContext(jobID string, context string) (*entity.JobRun, error) {
-	run, err := s.RunJob(jobID, "")
+	run, err := s.RunJob(jobID, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +355,7 @@ func (s *jobManagerService) RerunJob(jobID string, originalRunID string) (*entit
 	originalRun, err := s.findJobRun.FindJobRunByID(originalRunID)
 	if err != nil || originalRun == nil {
 		// Fallback: run without trigger context
-		return s.RunJob(jobID, "")
+		return s.RunJob(jobID, "", nil)
 	}
 
 	cid := originalRun.CorrelationID
@@ -341,13 +363,13 @@ func (s *jobManagerService) RerunJob(jobID string, originalRunID string) (*entit
 	parentRunID := originalRun.TriggeredBy
 	if parentRunID == "" {
 		// Original was manual, just run fresh
-		return s.RunJob(jobID, "", cid)
+		return s.RunJob(jobID, "", nil, cid)
 	}
 
 	// Rebuild trigger context from the parent run
 	parentRun, err := s.findJobRun.FindJobRunByID(parentRunID)
 	if err != nil || parentRun == nil {
-		return s.RunJob(jobID, "")
+		return s.RunJob(jobID, "", nil)
 	}
 
 	parentJob, _ := s.findJob.FindJobByID(parentRun.JobID)
@@ -357,13 +379,17 @@ func (s *jobManagerService) RerunJob(jobID string, originalRunID string) (*entit
 	}
 
 	sourceOutput := parentRun.Result
-	metadataSection := ""
-	if idx := strings.Index(sourceOutput, "\n\n--- metadata ---\n"); idx >= 0 {
-		metadataSection = sourceOutput[idx+len("\n\n--- metadata ---\n"):]
-		sourceOutput = sourceOutput[:idx]
-	}
 	if len(sourceOutput) > 3000 {
 		sourceOutput = sourceOutput[len(sourceOutput)-3000:]
+	}
+	// issue #50: source structured metadata from the parent's typed
+	// Metadata column rather than the legacy "\n\n--- metadata ---\n"
+	// suffix on Result (which we no longer write on success/failure).
+	var metadataSection string
+	if len(parentRun.Metadata) > 0 {
+		if b, mErr := json.Marshal(parentRun.Metadata); mErr == nil {
+			metadataSection = string(b)
+		}
 	}
 
 	triggerOn := "success"
@@ -388,7 +414,7 @@ func (s *jobManagerService) RerunJob(jobID string, originalRunID string) (*entit
 		)
 	}
 
-	newRun, err := s.RunJob(jobID, parentRunID, cid)
+	newRun, err := s.RunJob(jobID, parentRunID, nil, cid)
 	if err != nil {
 		return nil, err
 	}
@@ -497,7 +523,7 @@ func (s *jobManagerService) AdvancePipeline(runID string, targetJobID string, ex
 		return nil, fmt.Errorf("failed to update run: %w", err)
 	}
 
-	newRun, err := s.RunJob(targetJobID, "", run.CorrelationID)
+	newRun, err := s.RunJob(targetJobID, "", nil, run.CorrelationID)
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +558,36 @@ func (s *jobManagerService) executeWithRetries(job *entity.Job, run *entity.JobR
 		maxAttempts = 1
 	}
 
+	// issue #50: derive the typed inbound metadata once. For a TRIGGERED run,
+	// the parent's produced Metadata is the contract; for a ROOT run, the
+	// pre-seeded run.Metadata holds the inputs the caller passed to RunJob.
+	// We look up the parent fresh from the DB so we see the value persisted
+	// after the parent's finalizeMetadata (no in-memory map, no race).
+	var inbound map[string]any
+	if run.TriggeredBy != "" {
+		if parent, perr := s.findJobRun.FindJobRunByID(run.TriggeredBy); perr == nil && parent != nil {
+			inbound = parent.Metadata
+		}
+	} else {
+		inbound = run.Metadata
+	}
+
+	// issue #50: pre-run validation gate (hard fail; no LLM/bash invocation).
+	// On failure we still fire downstream triggers so an onFailure triage
+	// cascade can react — matching the upstream exec-error path.
+	if verr := validateInputs(job.Inputs, inbound); verr != nil {
+		now := time.Now()
+		run.Status = jobrunstatus.Failed
+		run.ValidationError = verr.Error()
+		run.ErrorMessage = "input validation failed: " + verr.Error()
+		run.FinishedAt = &now
+		_ = s.saveJobRun.UpdateJobRun(*run)
+		s.fireTriggers(job.ID, run, activeCSKey)
+		return
+	}
+
 	var lastOutput string
+	var lastValidationFeedback string
 	var lastErr error
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
@@ -547,7 +602,7 @@ func (s *jobManagerService) executeWithRetries(job *entity.Job, run *entity.JobR
 
 		switch job.Type {
 		case jobtype.Claude:
-			result, execErr = s.executeClaudeJob(job, run, attempt, lastOutput, activeCSKey)
+			result, execErr = s.executeClaudeJob(job, run, attempt, lastOutput, lastValidationFeedback, activeCSKey)
 		case jobtype.Bash:
 			result, execErr = s.executeBashJob(job, run)
 		default:
@@ -628,25 +683,68 @@ func (s *jobManagerService) executeWithRetries(job *entity.Job, run *entity.JobR
 					time.Sleep(3 * time.Second)
 					continue
 				}
-			} else {
-				run.Status = jobrunstatus.Success
+				// Final failure — fire onFailure triggers with empty Metadata
+				// (we deliberately don't propagate metadata from a failed task).
+				_ = s.saveJobRun.UpdateJobRun(*run)
+				s.fireTriggers(job.ID, run, activeCSKey)
+				return
 			}
 
-			// Store metadata as JSON in the result for triggered jobs to use
-			if metaJSON, err := json.Marshal(eval.Metadata); err == nil {
-				run.Result = result + "\n\n--- metadata ---\n" + string(metaJSON)
+			// --- issue #50: typed metadata extraction (success path) ---
+			// Sentinel <quant-output>{...}</quant-output> block wins; the LLM
+			// eval metadata is offered as a fallback only when the job
+			// declared a legacy MetadataPrompt. Output-validation errors fail
+			// the run closed so no garbage propagates to downstream jobs.
+			var evalFallback func() (map[string]any, error)
+			if job.MetadataPrompt != "" {
+				captured := eval.Metadata
+				evalFallback = func() (map[string]any, error) { return captured, nil }
 			}
-
+			finalMeta, extractErrs := finalizeMetadata(job.Outputs, result, inbound, evalFallback)
+			if len(extractErrs) > 0 {
+				feedback := joinExtractionErrs(extractErrs)
+				// issue #50: a Claude job that botches its declared output
+				// contract can usually self-correct. Rather than fail closed
+				// immediately, re-prompt with the exact errors and retry — but
+				// only while the retry budget allows. The errors are threaded
+				// into buildClaudePrompt so the agent is told precisely what to
+				// fix (missing key, wrong type, or malformed sentinel JSON).
+				if attempt < maxAttempts {
+					lastOutput = result
+					lastValidationFeedback = feedback
+					lastErr = fmt.Errorf("output validation failed: %s", feedback)
+					time.Sleep(3 * time.Second)
+					continue
+				}
+				run.Status = jobrunstatus.Failed
+				run.ValidationError = "output validation failed: " + feedback
+				run.ErrorMessage = run.ValidationError
+				_ = s.saveJobRun.UpdateJobRun(*run)
+				s.fireTriggers(job.ID, run, activeCSKey)
+				return
+			}
+			run.Metadata = finalMeta
+			run.Status = jobrunstatus.Success
 			_ = s.saveJobRun.UpdateJobRun(*run)
 			s.fireTriggers(job.ID, run, activeCSKey)
 			return
 		}
 
-		// Bash jobs — no evaluation, just success
+		// Bash jobs — issue #50 typed extraction (no LLM-eval fallback).
 		now := time.Now()
-		run.Status = jobrunstatus.Success
 		run.Result = result
 		run.FinishedAt = &now
+		bashMeta, bashErrs := finalizeMetadata(job.Outputs, result, inbound, nil)
+		if len(bashErrs) > 0 {
+			run.Status = jobrunstatus.Failed
+			run.ValidationError = "output validation failed: " + joinExtractionErrs(bashErrs)
+			run.ErrorMessage = run.ValidationError
+			_ = s.saveJobRun.UpdateJobRun(*run)
+			s.fireTriggers(job.ID, run, activeCSKey)
+			return
+		}
+		run.Metadata = bashMeta
+		run.Status = jobrunstatus.Success
 		_ = s.saveJobRun.UpdateJobRun(*run)
 		s.fireTriggers(job.ID, run, activeCSKey)
 		return
@@ -670,7 +768,7 @@ func (s *jobManagerService) executeWithRetries(job *entity.Job, run *entity.JobR
 // buildClaudePrompt wraps the user's prompt with autonomous job instructions.
 // On retries, includes the previous attempt's output for continuity.
 // When triggered by another job, includes the trigger context (source job name, outcome, output).
-func (s *jobManagerService) buildClaudePrompt(job *entity.Job, run *entity.JobRun, attempt int, previousOutput string) string {
+func (s *jobManagerService) buildClaudePrompt(job *entity.Job, run *entity.JobRun, attempt int, previousOutput string, validationFeedback string) string {
 	timeout := job.TimeoutSeconds
 	if timeout <= 0 {
 		timeout = 1800
@@ -712,6 +810,18 @@ func (s *jobManagerService) buildClaudePrompt(job *entity.Job, run *entity.JobRu
 		sb.WriteString("Continue from where the previous attempt left off.\n")
 	}
 
+	// issue #50: the previous attempt ran fine but did not satisfy this job's
+	// declared output contract. Tell the agent exactly what to fix so it can
+	// self-correct on this attempt instead of failing the run.
+	if validationFeedback != "" {
+		sb.WriteString("\n## Output contract not satisfied on the previous attempt\n")
+		sb.WriteString("Your previous response did not satisfy this job's declared output contract:\n")
+		sb.WriteString("  " + validationFeedback + "\n")
+		sb.WriteString("You MUST end your response with exactly one <quant-output>{...}</quant-output> block ")
+		sb.WriteString("containing valid JSON in which every declared produced key is present and correctly typed. ")
+		sb.WriteString("Fix only the problems listed above.\n")
+	}
+
 	sb.WriteString("\n## Task\n")
 	sb.WriteString(job.Prompt)
 
@@ -725,8 +835,8 @@ func (s *jobManagerService) buildClaudePrompt(job *entity.Job, run *entity.JobRu
 // When csKey is non-nil, the job participates in a shared chain session:
 //   - If the chain session already has a conversationID, --resume is used instead of a fresh session.
 //   - After completion, the conversation ID and token count are stored back on the chain session.
-func (s *jobManagerService) executeClaudeJob(job *entity.Job, run *entity.JobRun, attempt int, previousOutput string, csKey *chainSessionKey) (string, error) {
-	prompt := s.buildClaudePrompt(job, run, attempt, previousOutput)
+func (s *jobManagerService) executeClaudeJob(job *entity.Job, run *entity.JobRun, attempt int, previousOutput string, validationFeedback string, csKey *chainSessionKey) (string, error) {
+	prompt := s.buildClaudePrompt(job, run, attempt, previousOutput, validationFeedback)
 
 	claudeCmd := job.ClaudeCommand
 	if claudeCmd == "" {
@@ -1381,15 +1491,20 @@ func (s *jobManagerService) fireTriggers(jobID string, run *entity.JobRun, sourc
 		activeCSKey = sourceCSKey[0]
 	}
 
-	// Extract metadata from the run result (if present)
+	// issue #50: structured metadata for downstream jobs now comes from the
+	// parent's typed Metadata column (set by finalizeMetadata). The legacy
+	// "\n\n--- metadata ---\n" suffix on Result is gone on success/failure
+	// paths; only the upstream "waiting" branch still emits it for UI
+	// display and waiting doesn't reach this fireTriggers path anyway.
 	sourceOutput := run.Result
-	metadataSection := ""
-	if idx := strings.Index(sourceOutput, "\n\n--- metadata ---\n"); idx >= 0 {
-		metadataSection = sourceOutput[idx+len("\n\n--- metadata ---\n"):]
-		sourceOutput = sourceOutput[:idx]
-	}
 	if len(sourceOutput) > 3000 {
 		sourceOutput = sourceOutput[len(sourceOutput)-3000:]
+	}
+	var metadataSection string
+	if len(run.Metadata) > 0 {
+		if b, mErr := json.Marshal(run.Metadata); mErr == nil {
+			metadataSection = string(b)
+		}
 	}
 
 	for _, trigger := range triggers {
@@ -1429,7 +1544,7 @@ func (s *jobManagerService) fireTriggers(jobID string, run *entity.JobRun, sourc
 		}
 
 		// Store context for the new run to pick up
-		newRun, err := s.RunJob(trigger.TargetJobID, run.ID, run.CorrelationID)
+		newRun, err := s.RunJob(trigger.TargetJobID, run.ID, nil, run.CorrelationID)
 		if err == nil && newRun != nil {
 			s.mu.Lock()
 			// Append continue_pipeline context if present

--- a/internal/application/service/job_scheduler.go
+++ b/internal/application/service/job_scheduler.go
@@ -120,7 +120,7 @@ func (s *jobScheduler) checkAndRunDueJobs() {
 		}
 
 		fmt.Printf("scheduler: running job %s (%s)\n", job.Name, job.ID)
-		_, err := s.jobManager.RunJob(job.ID, "")
+		_, err := s.jobManager.RunJob(job.ID, "", nil)
 		if err != nil {
 			fmt.Printf("scheduler: failed to run job %s: %v\n", job.Name, err)
 		}

--- a/internal/application/service/output_extractor.go
+++ b/internal/application/service/output_extractor.go
@@ -1,0 +1,150 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"quant/internal/domain/entity"
+)
+
+// sentinelRe matches a <quant-output>...</quant-output> block. The capture
+// group is the JSON body. Non-greedy + DOTALL so multi-line JSON works and we
+// don't accidentally span across two blocks.
+//
+// We extract ALL matches (not just the first) so jobs can prepend transient
+// status lines and have the LAST sentinel be the source of truth.
+var sentinelRe = regexp.MustCompile(`(?s)<quant-output>\s*(\{.*?\})\s*</quant-output>`)
+
+// extractSentinelOutputs scans the FULL job output for the LAST
+// <quant-output>{...}</quant-output> block and parses its JSON body.
+//
+// Returns (parsed, true) when a valid block is found.
+// Returns (nil, false) when no block exists, or the last block's JSON is
+// malformed. (Earlier valid blocks are intentionally NOT used as fallback —
+// the contract is "the last block wins"; treating a malformed last block as
+// "no sentinel" lets the LLM-eval fallback engage and surfaces the bug
+// instead of silently using stale data.)
+func extractSentinelOutputs(output string) (map[string]any, bool) {
+	matches := sentinelRe.FindAllStringSubmatch(output, -1)
+	if len(matches) == 0 {
+		return nil, false
+	}
+	last := matches[len(matches)-1][1]
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(last), &parsed); err != nil {
+		return nil, false
+	}
+	return parsed, true
+}
+
+// applyPassthrough merges produced (extracted) outputs with inbound metadata
+// according to a job's declared output spec, enforcing passthrough integrity.
+//
+// Per spec entry:
+//   - source == "passthrough": value is copied verbatim from inbound; any
+//     value the job emitted for this key is DROPPED. Missing inbound value or
+//     type mismatch -> error string.
+//   - source == "produced" (or ""): value comes from produced; missing or
+//     wrong-type -> error string.
+//   - unknown source -> error string.
+//
+// Extra emitted keys NOT in the spec are dropped silently — when a spec is
+// declared, it is the contract.
+//
+// Returns the final metadata map and an ordered slice of error strings
+// (deterministic order matches the spec order so logs are stable).
+func applyPassthrough(specs []entity.JobOutputSpec, produced, inbound map[string]any) (map[string]any, []string) {
+	out := map[string]any{}
+	var errs []string
+	if produced == nil {
+		produced = map[string]any{}
+	}
+	if inbound == nil {
+		inbound = map[string]any{}
+	}
+
+	for _, s := range specs {
+		switch s.Source {
+		case "passthrough":
+			v, ok := inbound[s.Key]
+			if !ok {
+				errs = append(errs, fmt.Sprintf("passthrough output %q has no inbound value", s.Key))
+				continue
+			}
+			if !typeMatches(s.Type, v) {
+				errs = append(errs, fmt.Sprintf("passthrough output %q: inbound type %s != declared %s", s.Key, jsonTypeOf(v), s.Type))
+				continue
+			}
+			out[s.Key] = v
+		case "produced", "":
+			v, ok := produced[s.Key]
+			if !ok {
+				errs = append(errs, fmt.Sprintf("produced output %q missing from job result", s.Key))
+				continue
+			}
+			if !typeMatches(s.Type, v) {
+				errs = append(errs, fmt.Sprintf("produced output %q: %s != declared %s", s.Key, jsonTypeOf(v), s.Type))
+				continue
+			}
+			out[s.Key] = v
+		default:
+			errs = append(errs, fmt.Sprintf("output %q: unknown source %q", s.Key, s.Source))
+		}
+	}
+	return out, errs
+}
+
+// finalizeMetadata is the single entry point executeWithRetries calls after a
+// successful job execution. It runs the two-stage extraction (sentinel then
+// optional LLM eval fallback) and applies passthrough enforcement.
+//
+// Behavior matrix:
+//   - len(specs) == 0  -> permissive back-compat: return produced verbatim
+//     (or {} if nothing was extracted). No errors.
+//   - len(specs) >  0  -> strict: applyPassthrough governs the final map;
+//     errors are returned for the caller to mark the run failed.
+//
+// The fallback (`evalFallback`) is invoked only when there is NO sentinel
+// block AND the caller passed a non-nil callable (caller decides whether the
+// job qualifies — typically Claude jobs with a non-empty MetadataPrompt).
+// When the fallback errors or returns nil, produced stays nil and the strict
+// branch below will surface "missing" errors for any declared produced keys.
+func finalizeMetadata(
+	specs []entity.JobOutputSpec,
+	fullOutput string,
+	inbound map[string]any,
+	evalFallback func() (map[string]any, error),
+) (map[string]any, []string) {
+	produced, found := extractSentinelOutputs(fullOutput)
+	if !found && evalFallback != nil {
+		if fb, err := evalFallback(); err == nil && fb != nil {
+			produced = fb
+		}
+	}
+
+	if len(specs) == 0 {
+		// Back-compat permissive path: when no schema declared, expose
+		// whatever was produced (possibly nil -> {}) and skip validation.
+		if produced == nil {
+			return map[string]any{}, nil
+		}
+		return produced, nil
+	}
+
+	return applyPassthrough(specs, produced, inbound)
+}
+
+// joinExtractionErrs renders a slice of extraction errors as a stable,
+// deterministic single-line string for run.ValidationError / run.ErrorMessage.
+// Sorted alphabetically so log diffs are stable.
+func joinExtractionErrs(errs []string) string {
+	if len(errs) == 0 {
+		return ""
+	}
+	sorted := append([]string(nil), errs...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, "; ")
+}

--- a/internal/application/service/output_extractor_test.go
+++ b/internal/application/service/output_extractor_test.go
@@ -1,0 +1,299 @@
+package service
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"quant/internal/domain/entity"
+)
+
+// TestExtractSentinelOutputs tests the regex-based sentinel block extraction:
+// presence, absence, malformed JSON, and the multi-block "last wins" rule
+// documented in the source comment.
+func TestExtractSentinelOutputs(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		want   map[string]any
+		wantOK bool
+	}{
+		{
+			name:   "basic-single-block",
+			input:  `prefix <quant-output>{"a":1}</quant-output> suffix`,
+			want:   map[string]any{"a": float64(1)},
+			wantOK: true,
+		},
+		{
+			name:   "no-block-returns-false",
+			input:  `just plain text with no sentinel`,
+			want:   nil,
+			wantOK: false,
+		},
+		{
+			name:   "malformed-json-last-block-returns-false",
+			input:  `<quant-output>{not-json}</quant-output>`,
+			want:   nil,
+			wantOK: false,
+		},
+		{
+			name:   "multiple-blocks-last-wins",
+			input:  `<quant-output>{"a":1}</quant-output>...<quant-output>{"a":2,"b":3}</quant-output>`,
+			want:   map[string]any{"a": float64(2), "b": float64(3)},
+			wantOK: true,
+		},
+		{
+			name: "multiline-json-body",
+			input: "<quant-output>{\n  \"prUrl\": \"https://x/pr/1\",\n  \"status\": \"open\"\n}</quant-output>",
+			want: map[string]any{
+				"prUrl":  "https://x/pr/1",
+				"status": "open",
+			},
+			wantOK: true,
+		},
+		{
+			name:   "empty-input",
+			input:  "",
+			want:   nil,
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := extractSentinelOutputs(tc.input)
+			if ok != tc.wantOK {
+				t.Fatalf("ok=%v want=%v (got=%v)", ok, tc.wantOK, got)
+			}
+			if ok && !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplyPassthrough_OverridesProduced verifies that when a key is declared
+// passthrough the inbound value is used and any LLM-emitted value for that
+// same key is dropped.
+func TestApplyPassthrough_OverridesProduced(t *testing.T) {
+	specs := []entity.JobOutputSpec{
+		{Key: "linearId", Type: "string", Source: "passthrough"},
+		{Key: "prUrl", Type: "string", Source: "produced"},
+	}
+	produced := map[string]any{
+		"linearId": "LLM-LIES",
+		"prUrl":    "https://x/pr/1",
+		"rogue":    "dropped",
+	}
+	inbound := map[string]any{"linearId": "MAX-86"}
+
+	got, errs := applyPassthrough(specs, produced, inbound)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if got["linearId"] != "MAX-86" {
+		t.Errorf("passthrough not enforced: %v", got["linearId"])
+	}
+	if got["prUrl"] != "https://x/pr/1" {
+		t.Errorf("produced value lost: %v", got["prUrl"])
+	}
+	if _, has := got["rogue"]; has {
+		t.Errorf("rogue undeclared key was not dropped")
+	}
+}
+
+// TestApplyPassthrough_TypeMismatch_Produced ensures produced-source values
+// that don't match the declared type produce an error string.
+func TestApplyPassthrough_TypeMismatch_Produced(t *testing.T) {
+	specs := []entity.JobOutputSpec{
+		{Key: "count", Type: "number", Source: "produced"},
+	}
+	produced := map[string]any{"count": "not-a-number"}
+	_, errs := applyPassthrough(specs, produced, map[string]any{})
+	if len(errs) != 1 {
+		t.Fatalf("want 1 err, got %v", errs)
+	}
+	if !strings.Contains(errs[0], "count") || !strings.Contains(errs[0], "declared number") {
+		t.Errorf("err %q missing key/type details", errs[0])
+	}
+}
+
+// TestApplyPassthrough_TypeMismatch_Passthrough ensures passthrough values
+// that don't match the declared type produce an error string.
+func TestApplyPassthrough_TypeMismatch_Passthrough(t *testing.T) {
+	specs := []entity.JobOutputSpec{
+		{Key: "linearId", Type: "string", Source: "passthrough"},
+	}
+	inbound := map[string]any{"linearId": 42}
+	_, errs := applyPassthrough(specs, map[string]any{}, inbound)
+	if len(errs) != 1 {
+		t.Fatalf("want 1 err, got %v", errs)
+	}
+	if !strings.Contains(errs[0], "linearId") || !strings.Contains(errs[0], "declared string") {
+		t.Errorf("err %q missing key/type details", errs[0])
+	}
+}
+
+// TestApplyPassthrough_MissingProduced surfaces an error when a produced key
+// is required but absent.
+func TestApplyPassthrough_MissingProduced(t *testing.T) {
+	specs := []entity.JobOutputSpec{
+		{Key: "prUrl", Type: "string", Source: "produced"},
+	}
+	_, errs := applyPassthrough(specs, map[string]any{}, map[string]any{})
+	if len(errs) != 1 {
+		t.Fatalf("want 1 err, got %v", errs)
+	}
+	if !strings.Contains(errs[0], "prUrl") {
+		t.Errorf("err %q must name the missing key", errs[0])
+	}
+}
+
+// TestApplyPassthrough_MissingPassthrough surfaces an error when a
+// passthrough key is required but absent from inbound.
+func TestApplyPassthrough_MissingPassthrough(t *testing.T) {
+	specs := []entity.JobOutputSpec{
+		{Key: "linearId", Type: "string", Source: "passthrough"},
+	}
+	_, errs := applyPassthrough(specs, map[string]any{}, map[string]any{})
+	if len(errs) != 1 {
+		t.Fatalf("want 1 err, got %v", errs)
+	}
+	if !strings.Contains(errs[0], "linearId") {
+		t.Errorf("err %q must name the missing key", errs[0])
+	}
+}
+
+// TestApplyPassthrough_UnknownSource surfaces a deterministic error.
+func TestApplyPassthrough_UnknownSource(t *testing.T) {
+	specs := []entity.JobOutputSpec{
+		{Key: "x", Type: "string", Source: "magic"},
+	}
+	_, errs := applyPassthrough(specs, map[string]any{}, map[string]any{})
+	if len(errs) != 1 {
+		t.Fatalf("want 1 err, got %v", errs)
+	}
+	if !strings.Contains(errs[0], "magic") {
+		t.Errorf("err %q must name the bad source", errs[0])
+	}
+}
+
+// TestApplyPassthrough_DefaultSourceIsProduced verifies that Source=="" is
+// treated equivalently to "produced".
+func TestApplyPassthrough_DefaultSourceIsProduced(t *testing.T) {
+	specs := []entity.JobOutputSpec{
+		{Key: "prUrl", Type: "string"}, // Source omitted
+	}
+	produced := map[string]any{"prUrl": "https://x"}
+	got, errs := applyPassthrough(specs, produced, map[string]any{})
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if got["prUrl"] != "https://x" {
+		t.Errorf("default-source did not pick up produced value: %v", got)
+	}
+}
+
+// TestFinalizeMetadata_EmptySpecsPermissive ensures back-compat: when no
+// specs are declared, the sentinel output (or {}) is returned verbatim.
+func TestFinalizeMetadata_EmptySpecsPermissive(t *testing.T) {
+	t.Run("with-sentinel", func(t *testing.T) {
+		out, errs := finalizeMetadata(nil,
+			`<quant-output>{"any":"thing","extra":42}</quant-output>`,
+			nil, nil)
+		if len(errs) != 0 {
+			t.Fatalf("errs: %v", errs)
+		}
+		want := map[string]any{"any": "thing", "extra": float64(42)}
+		if !reflect.DeepEqual(out, want) {
+			t.Errorf("got %v want %v", out, want)
+		}
+	})
+	t.Run("without-sentinel-no-fallback", func(t *testing.T) {
+		out, errs := finalizeMetadata(nil, "no sentinel here", nil, nil)
+		if len(errs) != 0 {
+			t.Fatalf("errs: %v", errs)
+		}
+		if out == nil || len(out) != 0 {
+			t.Errorf("want empty non-nil map, got %v", out)
+		}
+	})
+}
+
+// TestFinalizeMetadata_StrictMixed exercises a realistic mixed schema with
+// both a passthrough key and a produced key in the same call.
+func TestFinalizeMetadata_StrictMixed(t *testing.T) {
+	specs := []entity.JobOutputSpec{
+		{Key: "linearId", Type: "string", Source: "passthrough"},
+		{Key: "prUrl", Type: "string", Source: "produced"},
+	}
+	output := `<quant-output>{"prUrl":"https://x/pr/1","linearId":"LLM-LIES"}</quant-output>`
+	inbound := map[string]any{"linearId": "MAX-86"}
+
+	out, errs := finalizeMetadata(specs, output, inbound, nil)
+	if len(errs) != 0 {
+		t.Fatalf("errs: %v", errs)
+	}
+	if out["linearId"] != "MAX-86" {
+		t.Errorf("passthrough not enforced: %v", out["linearId"])
+	}
+	if out["prUrl"] != "https://x/pr/1" {
+		t.Errorf("produced lost: %v", out["prUrl"])
+	}
+}
+
+// TestFinalizeMetadata_FallbackUsedWhenNoSentinel ensures the eval fallback
+// is invoked when (and only when) there is no sentinel block.
+func TestFinalizeMetadata_FallbackUsedWhenNoSentinel(t *testing.T) {
+	specs := []entity.JobOutputSpec{
+		{Key: "prUrl", Type: "string", Source: "produced"},
+	}
+	called := false
+	fallback := func() (map[string]any, error) {
+		called = true
+		return map[string]any{"prUrl": "https://x/from-eval"}, nil
+	}
+	out, errs := finalizeMetadata(specs, "no sentinel", nil, fallback)
+	if !called {
+		t.Fatalf("fallback was not invoked")
+	}
+	if len(errs) != 0 {
+		t.Fatalf("errs: %v", errs)
+	}
+	if out["prUrl"] != "https://x/from-eval" {
+		t.Errorf("fallback value not used: %v", out)
+	}
+}
+
+// TestFinalizeMetadata_FallbackSkippedWhenSentinelPresent verifies fallback
+// is bypassed once a sentinel block exists.
+func TestFinalizeMetadata_FallbackSkippedWhenSentinelPresent(t *testing.T) {
+	specs := []entity.JobOutputSpec{
+		{Key: "prUrl", Type: "string", Source: "produced"},
+	}
+	called := false
+	fallback := func() (map[string]any, error) {
+		called = true
+		return map[string]any{"prUrl": "should-not-be-used"}, nil
+	}
+	out, _ := finalizeMetadata(specs,
+		`<quant-output>{"prUrl":"https://x/from-sentinel"}</quant-output>`,
+		nil, fallback)
+	if called {
+		t.Errorf("fallback should not run when sentinel block exists")
+	}
+	if out["prUrl"] != "https://x/from-sentinel" {
+		t.Errorf("sentinel value should win: %v", out)
+	}
+}
+
+// TestJoinExtractionErrs verifies the deterministic alphabetical joining
+// used for log/error rendering.
+func TestJoinExtractionErrs(t *testing.T) {
+	if got := joinExtractionErrs(nil); got != "" {
+		t.Errorf("nil => %q want \"\"", got)
+	}
+	got := joinExtractionErrs([]string{"b err", "a err", "c err"})
+	if got != "a err; b err; c err" {
+		t.Errorf("unexpected order: %q", got)
+	}
+}

--- a/internal/application/service/output_feedback_prompt_test.go
+++ b/internal/application/service/output_feedback_prompt_test.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"quant/internal/domain/entity"
+)
+
+// TestBuildClaudePromptOutputFeedback covers issue #50's self-correction loop:
+// when a Claude job's previous attempt failed output-contract validation, the
+// next attempt's prompt must carry the exact errors plus an explicit instruction
+// to re-emit a valid <quant-output> block. When there is no feedback, that
+// section must be absent so normal runs aren't polluted.
+func TestBuildClaudePromptOutputFeedback(t *testing.T) {
+	s := &jobManagerService{} // zero value: no trigger context, no deps touched
+	job := &entity.Job{Prompt: "do the thing", TimeoutSeconds: 600}
+	run := &entity.JobRun{ID: "run-1"}
+
+	const feedback = `produced output "prUrl" missing from job result`
+
+	t.Run("feedback present on retry", func(t *testing.T) {
+		got := s.buildClaudePrompt(job, run, 2, "raw previous output", feedback)
+		for _, want := range []string{
+			"Output contract not satisfied on the previous attempt",
+			feedback,
+			"<quant-output>",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("prompt missing %q\n---\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("no feedback section on a clean first attempt", func(t *testing.T) {
+		got := s.buildClaudePrompt(job, run, 1, "", "")
+		if strings.Contains(got, "Output contract not satisfied") {
+			t.Errorf("unexpected feedback section in clean prompt\n---\n%s", got)
+		}
+	})
+}

--- a/internal/domain/entity/job.go
+++ b/internal/domain/entity/job.go
@@ -40,6 +40,13 @@ type Job struct {
 	ScriptContent string
 	EnvVariables  map[string]string
 
+	// issue #50: typed metadata contract. Inputs are validated against the
+	// job's inbound metadata before it runs (hard fail); Outputs declare what
+	// the job emits via its <quant-output> block ("produced") or copies
+	// verbatim from inbound ("passthrough").
+	Inputs  []JobInputSpec
+	Outputs []JobOutputSpec
+
 	WorkspaceID string
 
 	CreatedAt time.Time

--- a/internal/domain/entity/job_run.go
+++ b/internal/domain/entity/job_run.go
@@ -21,4 +21,11 @@ type JobRun struct {
 	InjectedContext string // context injected via trigger, resume, or pipeline advance
 	StartedAt       time.Time
 	FinishedAt   *time.Time
+
+	// issue #50: typed metadata pipeline. Metadata holds this run's produced
+	// outputs (after <quant-output> extraction + passthrough enforcement) and
+	// is what downstream triggered jobs receive as inbound. ValidationError
+	// records a pre-run input gate or output-validation failure for the UI.
+	Metadata        map[string]any
+	ValidationError string
 }

--- a/internal/domain/entity/job_schema.go
+++ b/internal/domain/entity/job_schema.go
@@ -1,0 +1,27 @@
+package entity
+
+// JobInputSpec declares one expected input for a job.
+//
+// Type values: "string" | "number" | "boolean" | "object" | "array".
+// Validation against an inbound payload happens in the pre-run gate
+// (internal/application/service/job_manager.go, executeWithRetries).
+type JobInputSpec struct {
+	Key      string `json:"key"`
+	Type     string `json:"type"`
+	Required bool   `json:"required"`
+}
+
+// JobOutputSpec declares one output the job is expected to emit
+// (sentinel block or LLM eval) OR pass through verbatim from inbound.
+//
+// Source values:
+//   - "produced"    : value must appear in the job's <quant-output>{...} block
+//     or be returned by the legacy LLM eval fallback.
+//   - "passthrough" : value is copied verbatim from inbound_metadata into the
+//     run's metadata; any value the job emits for this key is
+//     silently dropped.
+type JobOutputSpec struct {
+	Key    string `json:"key"`
+	Type   string `json:"type"`
+	Source string `json:"source"`
+}

--- a/internal/e2e/harness_test.go
+++ b/internal/e2e/harness_test.go
@@ -1,0 +1,312 @@
+// Package e2e contains end-to-end tests that boot the full Quant stack
+// in-process and drive it through the real MCP streamable-HTTP server using
+// the mark3labs/mcp-go client.
+//
+// SAFETY: every test isolates HOME to a t.TempDir() BEFORE the SQLite
+// connection is opened, so the real ~/.quant DB, ~/.mcp.json and ~/.claude are
+// never touched. Claude jobs use a fake `claude` script (never the real CLI).
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"quant/internal/infra/db"
+	"quant/internal/infra/dependency"
+	quantmcp "quant/internal/integration/mcp"
+)
+
+// harness wires the full stack and exposes an MCP client pointed at the real
+// /mcp endpoint.
+type harness struct {
+	t         *testing.T
+	home      string
+	server    *quantmcp.QuantMCPServer
+	client    *mcpclient.Client
+	wsID      string
+	ctx       context.Context
+}
+
+// newHarness boots the in-process stack with an isolated HOME and returns a
+// ready-to-use MCP client. It registers cleanup to stop the server and client.
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+
+	// SAFETY RULE 1: isolate HOME before the DB connection derives its path.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// SAFETY RULE 2: belt-and-suspenders (infra.Run is never called here).
+	t.Setenv("QUANT_SKIP_MCP_INJECT", "1")
+	t.Setenv("QUANT_SKIP_CLAUDE_CONFIG", "1")
+
+	database, err := db.NewSQLiteConnection()
+	if err != nil {
+		t.Fatalf("NewSQLiteConnection: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	// Verify the DB really landed under the temp HOME, not the real home.
+	dbPath := filepath.Join(home, ".quant", "quant.db")
+	if _, statErr := os.Stat(dbPath); statErr != nil {
+		t.Fatalf("expected DB at isolated HOME %s, but it is missing: %v", dbPath, statErr)
+	}
+
+	injector := dependency.NewInjector(database, nil)
+	server := quantmcp.NewQuantMCPServer(
+		injector.JobManager(),
+		injector.AgentManager(),
+		injector.SessionManager(),
+		injector.WorkspaceManager(),
+		injector.RepoManager(),
+		injector.JobGroupManager(),
+	)
+	if err := server.Start(); err != nil {
+		t.Fatalf("server.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Stop() })
+
+	ctx := context.Background()
+	url := fmt.Sprintf("http://localhost:%d/mcp", server.Port())
+	client, err := mcpclient.NewStreamableHttpClient(url)
+	if err != nil {
+		t.Fatalf("NewStreamableHttpClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("client.Start: %v", err)
+	}
+
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{Name: "quant-e2e", Version: "1.0.0"}
+	if _, err := client.Initialize(ctx, initReq); err != nil {
+		t.Fatalf("client.Initialize: %v", err)
+	}
+
+	h := &harness{t: t, home: home, server: server, client: client, ctx: ctx}
+
+	// Every test runs against the always-present Default workspace.
+	ws := h.call("get_current_workspace", nil)
+	id, _ := ws["id"].(string)
+	if id == "" {
+		t.Fatalf("could not resolve current workspace id from %v", ws)
+	}
+	h.wsID = id
+
+	return h
+}
+
+// call invokes an MCP tool and unmarshals the returned text content into a
+// map[string]any. It fails the test if the tool returned an error result.
+func (h *harness) call(tool string, args map[string]any) map[string]any {
+	h.t.Helper()
+	text := h.callRaw(tool, args, false)
+	var m map[string]any
+	if err := json.Unmarshal([]byte(text), &m); err != nil {
+		h.t.Fatalf("tool %s: result is not a JSON object: %v\nraw: %s", tool, err, text)
+	}
+	return m
+}
+
+// callExpectError invokes a tool that is expected to fail and returns the error
+// text. Fails the test if the tool unexpectedly succeeded.
+func (h *harness) callExpectError(tool string, args map[string]any) string {
+	h.t.Helper()
+	return h.callRaw(tool, args, true)
+}
+
+// callRaw performs the actual CallTool and returns the first text content.
+// When wantError is true it asserts IsError; otherwise it asserts no error.
+func (h *harness) callRaw(tool string, args map[string]any, wantError bool) string {
+	h.t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Name = tool
+	if args != nil {
+		req.Params.Arguments = args
+	}
+	res, err := h.client.CallTool(h.ctx, req)
+	if err != nil {
+		h.t.Fatalf("CallTool(%s) transport error: %v", tool, err)
+	}
+	text := firstText(h.t, res)
+	if wantError && !res.IsError {
+		h.t.Fatalf("tool %s expected an error result, got success: %s", tool, text)
+	}
+	if !wantError && res.IsError {
+		h.t.Fatalf("tool %s returned error result: %s", tool, text)
+	}
+	return text
+}
+
+func firstText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	if len(res.Content) == 0 {
+		t.Fatalf("tool result had no content")
+	}
+	tc, ok := mcp.AsTextContent(res.Content[0])
+	if !ok {
+		t.Fatalf("tool result content[0] is not text: %T", res.Content[0])
+	}
+	return tc.Text
+}
+
+// pollRunTerminal polls get_run until the run reaches a terminal status or the
+// timeout elapses. Returns the final run map.
+func (h *harness) pollRunTerminal(runID string, timeout time.Duration) map[string]any {
+	h.t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last map[string]any
+	for time.Now().Before(deadline) {
+		last = h.call("get_run", map[string]any{"runId": runID})
+		if isTerminal(last["status"]) {
+			return last
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	h.t.Fatalf("run %s did not reach terminal status within %v (last status: %v)", runID, timeout, last["status"])
+	return nil
+}
+
+// pollCorrelationJob polls list_runs_by_correlation until a run for jobID
+// reaches a terminal status, then returns its summary map. Useful for waiting
+// on downstream cascade jobs whose run IDs are not known up front.
+func (h *harness) pollCorrelationJob(correlationID, jobID string, timeout time.Duration) map[string]any {
+	h.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		res := h.call("list_runs_by_correlation", map[string]any{"correlationId": correlationID})
+		runs, _ := res["runs"].([]any)
+		for _, r := range runs {
+			rm, _ := r.(map[string]any)
+			if rm == nil {
+				continue
+			}
+			if rm["jobId"] == jobID && isTerminal(rm["status"]) {
+				return rm
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	h.t.Fatalf("no terminal run for job %s under correlation %s within %v", jobID, correlationID, timeout)
+	return nil
+}
+
+func isTerminal(status any) bool {
+	switch status {
+	case "success", "failed", "waiting", "cancelled", "timed_out":
+		return true
+	}
+	return false
+}
+
+// writeFakeClaude writes an executable fake `claude` script into dir and
+// returns its absolute path. The script handles both invocation modes:
+//
+//   - TASK mode (args contain "stream-json"): increments a per-job counter
+//     file, appends the prompt (stdin) to attempt-<n>.prompt, then emits
+//     stream-json. The emitted <quant-output> block depends on `mode`:
+//       "selfcorrect" -> attempt 1 violates the contract (missing prUrl),
+//                        attempt 2 satisfies it.
+//       "alwaysbad"   -> every attempt violates the contract.
+//   - EVAL mode (no "stream-json"): prints {"result":"success","metadata":{}}.
+//
+// stateDir is where the counter + prompt files live (pass a unique dir per job
+// via the job's workingDirectory so parallel/sequential jobs don't collide).
+func writeFakeClaude(t *testing.T, dir, mode, validValue string) string {
+	t.Helper()
+	path := filepath.Join(dir, "fake-claude.sh")
+	script := fmt.Sprintf(`#!/bin/bash
+set -e
+STATE_DIR="${QUANT_FAKE_STATE_DIR:-$PWD}"
+mkdir -p "$STATE_DIR"
+
+is_task=0
+for a in "$@"; do
+  if [ "$a" = "stream-json" ]; then is_task=1; fi
+done
+
+if [ "$is_task" = "0" ]; then
+  # EVAL mode: plain -p call, raw JSON object reply.
+  printf '%%s\n' '{"result":"success","metadata":{}}'
+  exit 0
+fi
+
+# TASK mode: count invocations and capture the prompt per attempt.
+COUNT_FILE="$STATE_DIR/task_count"
+n=0
+if [ -f "$COUNT_FILE" ]; then n=$(cat "$COUNT_FILE"); fi
+n=$((n+1))
+printf '%%s' "$n" > "$COUNT_FILE"
+cat > "$STATE_DIR/attempt-$n.prompt"
+
+MODE=%q
+VALID=%q
+
+emit() {
+  # $1 = the <quant-output> JSON body (with raw double quotes).
+  # Build the assistant 'text' value, then escape it exactly ONCE so the
+  # whole stream-json line is valid JSON while the extracted text still
+  # contains a clean <quant-output>{...}</quant-output> block.
+  local text="working...
+<quant-output>$1</quant-output>"
+  local t=${text//\\/\\\\}
+  t=${t//\"/\\\"}
+  t=${t//$'\n'/\\n}
+  printf '%%s\n' "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"${t}\"}]}}"
+  printf '%%s\n' "{\"type\":\"result\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5},\"session_id\":\"fake-sess\",\"model\":\"fake-model\",\"result\":\"done\"}"
+}
+
+case "$MODE" in
+  selfcorrect)
+    if [ "$n" = "1" ]; then
+      # Contract violation: omit the required produced key prUrl.
+      emit "{\"somethingElse\":\"nope\"}"
+    else
+      emit "{\"prUrl\":\"$VALID\"}"
+    fi
+    ;;
+  alwaysbad)
+    # Always violate: prUrl present but wrong type (number, not string).
+    emit "{\"prUrl\":123}"
+    ;;
+  *)
+    emit "{\"prUrl\":\"$VALID\"}"
+    ;;
+esac
+exit 0
+`, mode, validValue)
+
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	return path
+}
+
+// specJSON marshals input/output specs to the JSON string the MCP tools expect.
+func specJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal spec: %v", err)
+	}
+	return string(b)
+}
+
+// jsonStr marshals an arbitrary value to a JSON string (for the inputs arg).
+func jsonStr(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}

--- a/internal/e2e/pipeline_test.go
+++ b/internal/e2e/pipeline_test.go
@@ -1,0 +1,366 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"quant/internal/domain/entity"
+)
+
+const pollTimeout = 30 * time.Second
+
+// in is a tiny constructor for an input spec.
+func in(key, typ string, required bool) entity.JobInputSpec {
+	return entity.JobInputSpec{Key: key, Type: typ, Required: required}
+}
+
+// outP / outT build produced / passthrough output specs.
+func outP(key, typ string) entity.JobOutputSpec {
+	return entity.JobOutputSpec{Key: key, Type: typ, Source: "produced"}
+}
+func outT(key, typ string) entity.JobOutputSpec {
+	return entity.JobOutputSpec{Key: key, Type: typ, Source: "passthrough"}
+}
+
+// createBash creates a bash job and returns its id.
+func (h *harness) createBash(t *testing.T, name, script string, inputs []entity.JobInputSpec, outputs []entity.JobOutputSpec) string {
+	t.Helper()
+	args := map[string]any{
+		"name":           name,
+		"type":           "bash",
+		"workspaceId":    h.wsID,
+		"interpreter":    "/bin/bash",
+		"scriptContent":  script,
+		"timeoutSeconds": 60,
+	}
+	if inputs != nil {
+		args["inputs"] = specJSON(t, inputs)
+	}
+	if outputs != nil {
+		args["outputs"] = specJSON(t, outputs)
+	}
+	job := h.call("create_job", args)
+	id, _ := job["id"].(string)
+	if id == "" {
+		t.Fatalf("create_job %s returned no id: %v", name, job)
+	}
+	return id
+}
+
+// TestScenario1_TypedContractBashChain validates the deterministic A->B->C
+// typed-metadata chain: last-block-wins, passthrough integrity (no HACKED),
+// type preservation, and correlation propagation.
+func TestScenario1_TypedContractBashChain(t *testing.T) {
+	h := newHarness(t)
+
+	markerPath := filepath.Join(t.TempDir(), "triage-marker-s1")
+
+	// Job A: echoes chatter + a DECOY block, then the REAL final block.
+	// The decoy sets prUrl to a wrong value; the last block must win.
+	scriptA := `echo "human chatter line one"
+echo '<quant-output>{"prUrl":"https://decoy/DECOY","filesChanged":0,"labels":[],"analysis":{}}</quant-output>'
+echo "more chatter"
+echo '<quant-output>{"prUrl":"https://github.com/x/y/pull/42","filesChanged":7,"labels":["bug","urgent"],"analysis":{"risk":"low","score":3}}</quant-output>'`
+	aID := h.createBash(t, "s1-job-A", scriptA,
+		[]entity.JobInputSpec{in("linearId", "string", true), in("priority", "number", true), in("dryRun", "boolean", true)},
+		[]entity.JobOutputSpec{outP("prUrl", "string"), outP("filesChanged", "number"), outP("labels", "array"), outP("analysis", "object"),
+			outT("linearId", "string"), outT("priority", "number"), outT("dryRun", "boolean")})
+
+	// Job B: tries to HACK linearId (must be dropped by passthrough), produces
+	// reviewBucket + deployTarget.
+	scriptB := `echo '<quant-output>{"linearId":"HACKED","reviewBucket":"fast-track","deployTarget":"staging"}</quant-output>'`
+	bID := h.createBash(t, "s1-job-B", scriptB,
+		[]entity.JobInputSpec{in("linearId", "string", true), in("priority", "number", true), in("dryRun", "boolean", true),
+			in("prUrl", "string", true), in("filesChanged", "number", true), in("labels", "array", true), in("analysis", "object", true)},
+		[]entity.JobOutputSpec{outP("reviewBucket", "string"), outP("deployTarget", "string"),
+			outT("linearId", "string"), outT("priority", "number"), outT("dryRun", "boolean"), outT("prUrl", "string"), outT("analysis", "object")})
+
+	// Job C: terminal node, produces finalStatus.
+	scriptC := `echo '<quant-output>{"finalStatus":"complete"}</quant-output>'`
+	cID := h.createBash(t, "s1-job-C", scriptC,
+		[]entity.JobInputSpec{in("linearId", "string", true), in("reviewBucket", "string", true), in("deployTarget", "string", true),
+			in("prUrl", "string", true), in("analysis", "object", true)},
+		[]entity.JobOutputSpec{outP("finalStatus", "string"), outT("linearId", "string"), outT("prUrl", "string")})
+
+	// Job T: triage marker (onFailure target for A).
+	scriptT := `echo "triage" > "` + markerPath + `"`
+	tID := h.createBash(t, "s1-job-T", scriptT, nil, nil)
+
+	// Wire triggers: A.onSuccess=[B], A.onFailure=[T], B.onSuccess=[C].
+	h.call("update_job", map[string]any{"id": aID, "onSuccess": jsonStr(t, []string{bID}), "onFailure": jsonStr(t, []string{tID})})
+	h.call("update_job", map[string]any{"id": bID, "onSuccess": jsonStr(t, []string{cID})})
+
+	// Run A with valid typed inputs.
+	rootRun := h.call("run_job", map[string]any{"id": aID, "inputs": jsonStr(t, map[string]any{
+		"linearId": "MAX-1234", "priority": 3, "dryRun": true})})
+	rootRunID, _ := rootRun["id"].(string)
+	correlationID, _ := rootRun["correlationId"].(string)
+	if rootRunID == "" || correlationID == "" {
+		t.Fatalf("run_job A missing id/correlationId: %v", rootRun)
+	}
+
+	// Wait for A, then C (terminal) to complete via the cascade.
+	h.pollRunTerminal(rootRunID, pollTimeout)
+	h.pollCorrelationJob(correlationID, cID, pollTimeout)
+
+	// Gather full run objects for each job under the correlation.
+	corr := h.call("list_runs_by_correlation", map[string]any{"correlationId": correlationID})
+	runs, _ := corr["runs"].([]any)
+	byJob := map[string]string{} // jobID -> runID
+	for _, r := range runs {
+		rm, _ := r.(map[string]any)
+		if rm == nil {
+			continue
+		}
+		jid, _ := rm["jobId"].(string)
+		rid, _ := rm["id"].(string)
+		// All runs must share the correlation id.
+		if cid, _ := rm["correlationId"].(string); cid != correlationID {
+			t.Errorf("run %s has correlationId %q, expected %q", rid, cid, correlationID)
+		}
+		byJob[jid] = rid
+	}
+
+	for _, jid := range []string{aID, bID, cID} {
+		if byJob[jid] == "" {
+			t.Fatalf("no run found for job %s under correlation", jid)
+		}
+	}
+
+	aRun := h.call("get_run", map[string]any{"runId": byJob[aID]})
+	bRun := h.call("get_run", map[string]any{"runId": byJob[bID]})
+	cRun := h.call("get_run", map[string]any{"runId": byJob[cID]})
+
+	// All three succeeded.
+	for name, run := range map[string]map[string]any{"A": aRun, "B": bRun, "C": cRun} {
+		if run["status"] != "success" {
+			t.Errorf("job %s expected status success, got %v (validationError=%v)", name, run["status"], run["validationError"])
+		}
+	}
+
+	aMeta, _ := aRun["metadata"].(map[string]any)
+	bMeta, _ := bRun["metadata"].(map[string]any)
+	cMeta, _ := cRun["metadata"].(map[string]any)
+
+	// Last-block-wins: A's prUrl is the REAL block, not the decoy.
+	if aMeta["prUrl"] != "https://github.com/x/y/pull/42" {
+		t.Errorf("A last-block-wins failed: prUrl=%v (decoy leaked?)", aMeta["prUrl"])
+	}
+	// Type preservation in A.
+	if _, ok := aMeta["analysis"].(map[string]any); !ok {
+		t.Errorf("A analysis should be object, got %T (%v)", aMeta["analysis"], aMeta["analysis"])
+	}
+	if _, ok := aMeta["labels"].([]any); !ok {
+		t.Errorf("A labels should be array, got %T (%v)", aMeta["labels"], aMeta["labels"])
+	}
+	if _, ok := aMeta["priority"].(float64); !ok {
+		t.Errorf("A priority should be number, got %T (%v)", aMeta["priority"], aMeta["priority"])
+	}
+	if _, ok := aMeta["dryRun"].(bool); !ok {
+		t.Errorf("A dryRun should be bool, got %T (%v)", aMeta["dryRun"], aMeta["dryRun"])
+	}
+
+	// Passthrough integrity: B's linearId is the root value, NOT "HACKED".
+	if bMeta["linearId"] != "MAX-1234" {
+		t.Errorf("B passthrough integrity failed: linearId=%v (expected MAX-1234, HACK should be dropped)", bMeta["linearId"])
+	}
+	// B carried A's produced prUrl + analysis through passthrough.
+	if bMeta["prUrl"] != "https://github.com/x/y/pull/42" {
+		t.Errorf("B should carry A's prUrl, got %v", bMeta["prUrl"])
+	}
+	if bMeta["reviewBucket"] != "fast-track" || bMeta["deployTarget"] != "staging" {
+		t.Errorf("B produced outputs wrong: reviewBucket=%v deployTarget=%v", bMeta["reviewBucket"], bMeta["deployTarget"])
+	}
+
+	// C's inbound got B-derived reviewBucket/deployTarget AND A's prUrl AND root linearId.
+	if cMeta["finalStatus"] != "complete" {
+		t.Errorf("C finalStatus wrong: %v", cMeta["finalStatus"])
+	}
+	if cMeta["linearId"] != "MAX-1234" {
+		t.Errorf("C linearId passthrough wrong: %v", cMeta["linearId"])
+	}
+	if cMeta["prUrl"] != "https://github.com/x/y/pull/42" {
+		t.Errorf("C prUrl passthrough wrong: %v", cMeta["prUrl"])
+	}
+
+	// Triage marker must NOT exist (A succeeded, onFailure didn't fire).
+	if _, err := os.Stat(markerPath); err == nil {
+		t.Errorf("triage marker exists but A succeeded — onFailure should not have fired")
+	}
+}
+
+// TestScenario2_InputGateNegatives validates the pre-run input gate: missing
+// required input and wrong-typed input both fail BEFORE execution, and the
+// onFailure triage cascade fires on the missing-input case.
+func TestScenario2_InputGateNegatives(t *testing.T) {
+	h := newHarness(t)
+
+	t.Run("missing_required_input_fires_triage", func(t *testing.T) {
+		markerPath := filepath.Join(t.TempDir(), "triage-marker-missing")
+
+		aScript := `echo '<quant-output>{"prUrl":"https://x/y/1"}</quant-output>'`
+		aID := h.createBash(t, "s2a-job-A", aScript,
+			[]entity.JobInputSpec{in("linearId", "string", true), in("priority", "number", true), in("dryRun", "boolean", true)},
+			[]entity.JobOutputSpec{outP("prUrl", "string")})
+		tScript := `echo "triage" > "` + markerPath + `"`
+		tID := h.createBash(t, "s2a-job-T", tScript, nil, nil)
+		h.call("update_job", map[string]any{"id": aID, "onFailure": jsonStr(t, []string{tID})})
+
+		// Missing required linearId.
+		run := h.call("run_job", map[string]any{"id": aID, "inputs": jsonStr(t, map[string]any{"priority": 3})})
+		runID, _ := run["id"].(string)
+		correlationID, _ := run["correlationId"].(string)
+		final := h.pollRunTerminal(runID, pollTimeout)
+
+		if final["status"] != "failed" {
+			t.Errorf("expected failed, got %v", final["status"])
+		}
+		ve, _ := final["validationError"].(string)
+		if !strings.Contains(ve, "linearId") {
+			t.Errorf("validationError should mention linearId, got %q", ve)
+		}
+		if tok, _ := final["tokensUsed"].(float64); tok != 0 {
+			t.Errorf("expected ~0 tokens (no execution), got %v", tok)
+		}
+		// onFailure triage cascade fired -> marker exists.
+		h.pollCorrelationJob(correlationID, tID, pollTimeout)
+		if _, err := os.Stat(markerPath); err != nil {
+			t.Errorf("triage marker missing — onFailure cascade did not fire: %v", err)
+		}
+	})
+
+	t.Run("wrong_typed_input_no_execution", func(t *testing.T) {
+		// Fresh job; produced block would set a sentinel if it ran. We assert it
+		// does NOT run by checking failure + no metadata + type-problem message.
+		aID := h.createBash(t, "s2b-job-A", `echo '<quant-output>{"prUrl":"https://x/y/2"}</quant-output>'`,
+			[]entity.JobInputSpec{in("linearId", "string", true), in("priority", "number", true), in("dryRun", "boolean", true)},
+			[]entity.JobOutputSpec{outP("prUrl", "string")})
+
+		// linearId is a number, not a string -> type mismatch.
+		run := h.call("run_job", map[string]any{"id": aID, "inputs": jsonStr(t, map[string]any{
+			"linearId": 123, "priority": 3, "dryRun": true})})
+		runID, _ := run["id"].(string)
+		final := h.pollRunTerminal(runID, pollTimeout)
+
+		if final["status"] != "failed" {
+			t.Errorf("expected failed, got %v", final["status"])
+		}
+		ve, _ := final["validationError"].(string)
+		if !strings.Contains(ve, "linearId") || !strings.Contains(ve, "expected") {
+			t.Errorf("validationError should indicate a type problem for linearId, got %q", ve)
+		}
+		// The gate blocked execution before the script ran, so no PRODUCED
+		// output exists. (Root-run metadata still holds the seeded inputs — the
+		// failed gate never overwrites it with produced outputs.)
+		if meta, _ := final["metadata"].(map[string]any); meta["prUrl"] != nil {
+			t.Errorf("expected no produced prUrl (gate should block execution), got %v", meta["prUrl"])
+		}
+	})
+}
+
+// TestScenario3_ClaudeSelfCorrection validates the Claude output-contract
+// self-correction loop and the fail-closed behavior without retry budget.
+func TestScenario3_ClaudeSelfCorrection(t *testing.T) {
+	h := newHarness(t)
+
+	t.Run("self_corrects_within_retry_budget", func(t *testing.T) {
+		workDir := t.TempDir()
+		fake := writeFakeClaude(t, workDir, "selfcorrect", "https://github.com/x/y/pull/99")
+
+		job := h.call("create_job", map[string]any{
+			"name":           "s3-job-D",
+			"type":           "claude",
+			"workspaceId":    h.wsID,
+			"prompt":         "produce the pr url",
+			"claudeCommand":  fake,
+			"workingDirectory": workDir,
+			"maxRetries":     1,
+			"allowBypass":    true,
+			"timeoutSeconds": 60,
+			"outputs":        specJSON(t, []entity.JobOutputSpec{outP("prUrl", "string")}),
+		})
+		dID, _ := job["id"].(string)
+
+		run := h.call("run_job", map[string]any{"id": dID})
+		runID, _ := run["id"].(string)
+		final := h.pollRunTerminal(runID, pollTimeout)
+
+		if final["status"] != "success" {
+			t.Fatalf("expected success after self-correction, got %v (validationError=%v)", final["status"], final["validationError"])
+		}
+		meta, _ := final["metadata"].(map[string]any)
+		if meta["prUrl"] != "https://github.com/x/y/pull/99" {
+			t.Errorf("expected corrected prUrl, got %v", meta["prUrl"])
+		}
+
+		// Counter shows exactly 2 task invocations (one retry).
+		count := readCount(t, workDir)
+		if count != 2 {
+			t.Errorf("expected 2 fake-claude task invocations, got %d", count)
+		}
+		// Attempt-2 prompt carried the corrective feedback.
+		p2 := filepath.Join(workDir, "attempt-2.prompt")
+		data, err := os.ReadFile(p2)
+		if err != nil {
+			t.Fatalf("read attempt-2 prompt: %v", err)
+		}
+		if !strings.Contains(string(data), "Output contract not satisfied") {
+			t.Errorf("attempt-2 prompt missing corrective feedback section; got:\n%s", string(data))
+		}
+	})
+
+	t.Run("fails_closed_without_retry_budget", func(t *testing.T) {
+		workDir := t.TempDir()
+		fake := writeFakeClaude(t, workDir, "alwaysbad", "")
+
+		job := h.call("create_job", map[string]any{
+			"name":           "s3-job-E",
+			"type":           "claude",
+			"workspaceId":    h.wsID,
+			"prompt":         "produce the pr url",
+			"claudeCommand":  fake,
+			"workingDirectory": workDir,
+			"maxRetries":     0,
+			"allowBypass":    true,
+			"timeoutSeconds": 60,
+			"outputs":        specJSON(t, []entity.JobOutputSpec{outP("prUrl", "string")}),
+		})
+		eID, _ := job["id"].(string)
+
+		run := h.call("run_job", map[string]any{"id": eID})
+		runID, _ := run["id"].(string)
+		final := h.pollRunTerminal(runID, pollTimeout)
+
+		if final["status"] != "failed" {
+			t.Fatalf("expected failed, got %v", final["status"])
+		}
+		ve, _ := final["validationError"].(string)
+		if !strings.HasPrefix(ve, "output validation failed") {
+			t.Errorf("validationError should start with 'output validation failed', got %q", ve)
+		}
+		// No self-correction retry without budget: exactly 1 task invocation.
+		count := readCount(t, workDir)
+		if count != 1 {
+			t.Errorf("expected exactly 1 fake-claude task invocation (no retry), got %d", count)
+		}
+	})
+}
+
+func readCount(t *testing.T, workDir string) int {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(workDir, "task_count"))
+	if err != nil {
+		t.Fatalf("read task_count: %v", err)
+	}
+	n := 0
+	for _, c := range strings.TrimSpace(string(data)) {
+		if c < '0' || c > '9' {
+			t.Fatalf("non-numeric task_count: %q", string(data))
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}

--- a/internal/infra/db/sqlite.go
+++ b/internal/infra/db/sqlite.go
@@ -287,6 +287,18 @@ func runMigrations(db *sql.DB) error {
 		`ALTER TABLE jobs ADD COLUMN triage_prompt TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE job_runs ADD COLUMN correlation_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE job_runs ADD COLUMN injected_context TEXT NOT NULL DEFAULT ''`,
+		// --- issue #50: typed metadata pipeline ---
+		// jobs.inputs/outputs hold the declared JobInputSpec/JobOutputSpec
+		// arrays (JSON-encoded). job_runs.metadata holds the produced outputs
+		// after sentinel extraction + passthrough enforcement and is what
+		// downstream triggered jobs receive as inbound. validation_error
+		// records a pre-run input gate or output validation failure for the UI.
+		// We deliberately ride on upstream's correlation_id + injected_context
+		// — no separate correlation_metadata/inbound_metadata columns.
+		`ALTER TABLE jobs     ADD COLUMN inputs            TEXT NOT NULL DEFAULT '[]'`,
+		`ALTER TABLE jobs     ADD COLUMN outputs           TEXT NOT NULL DEFAULT '[]'`,
+		`ALTER TABLE job_runs ADD COLUMN metadata          TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE job_runs ADD COLUMN validation_error  TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range alterStatements {
 		// Ignore errors from ALTER TABLE since the column may already exist.

--- a/internal/infra/paths/paths.go
+++ b/internal/infra/paths/paths.go
@@ -1,0 +1,58 @@
+// Package paths centralizes resolution of filesystem paths used by quant.
+// All callers that previously joined os.UserHomeDir() with a static suffix
+// should funnel through this package so that E2E and tests can redirect data
+// off ~/.quant/ via the QUANT_HOME env var without touching user runtime data.
+package paths
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// QuantHome returns the root data directory for quant.
+// Order of precedence:
+//  1. $QUANT_HOME if non-empty
+//  2. $HOME/.quant
+//
+// The directory is NOT created here; callers must MkdirAll as needed.
+func QuantHome() string {
+	if v := os.Getenv("QUANT_HOME"); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// last-resort fallback so we never panic on lookup
+		return ".quant"
+	}
+	return filepath.Join(home, ".quant")
+}
+
+// MCPConfigPath returns the registered .mcp.json path. When QUANT_HOME is set,
+// the file lives inside that dir (so E2E does not mutate ~/.mcp.json).
+// Otherwise it lives at $HOME/.mcp.json.
+func MCPConfigPath() string {
+	if v := os.Getenv("QUANT_HOME"); v != "" {
+		return filepath.Join(v, ".mcp.json")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".mcp.json")
+}
+
+// SkipClaudeConfigDiscovery reports whether the boot should skip touching
+// ~/.claude*/settings.local.json. Set QUANT_SKIP_CLAUDE_CONFIG=1 for E2E.
+func SkipClaudeConfigDiscovery() bool {
+	return os.Getenv("QUANT_SKIP_CLAUDE_CONFIG") == "1"
+}
+
+// UserHome returns the user's home directory ("" on error). This is a thin
+// indirection over os.UserHomeDir so non-quant paths (shell rc files,
+// ~/Library/LaunchAgents, real Claude configs) can be resolved through a
+// single chokepoint that tests can stub if needed. It does NOT honor
+// QUANT_HOME — for quant-data paths use QuantHome() instead.
+func UserHome() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return home
+}

--- a/internal/integration/entrypoint/controller/job.go
+++ b/internal/integration/entrypoint/controller/job.go
@@ -62,6 +62,8 @@ func (c *jobController) CreateJob(request dto.CreateJobRequest) (*dto.JobRespons
 		Interpreter:         request.Interpreter,
 		ScriptContent:       request.ScriptContent,
 		EnvVariables:        request.EnvVariables,
+		Inputs:              request.Inputs,
+		Outputs:             request.Outputs,
 		WorkspaceID:         request.WorkspaceID,
 	}
 
@@ -106,6 +108,8 @@ func (c *jobController) UpdateJob(request dto.UpdateJobRequest) (*dto.JobRespons
 		Interpreter:         request.Interpreter,
 		ScriptContent:       request.ScriptContent,
 		EnvVariables:        request.EnvVariables,
+		Inputs:              request.Inputs,
+		Outputs:             request.Outputs,
 		WorkspaceID:         request.WorkspaceID,
 	}
 
@@ -154,7 +158,7 @@ func (c *jobController) ListJobs() ([]dto.JobResponse, error) {
 
 // RunJob starts a new run for a job.
 func (c *jobController) RunJob(id string) (*dto.JobRunResponse, error) {
-	run, err := c.jobManager.RunJob(id, "")
+	run, err := c.jobManager.RunJob(id, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/integration/entrypoint/dto/job.go
+++ b/internal/integration/entrypoint/dto/job.go
@@ -7,100 +7,109 @@ import (
 
 // CreateJobRequest represents the request payload for creating a new job.
 type CreateJobRequest struct {
-	Name                string            `json:"name"`
-	Description         string            `json:"description"`
-	Type                string            `json:"type"`
-	WorkingDirectory    string            `json:"workingDirectory"`
-	ScheduleEnabled     bool              `json:"scheduleEnabled"`
-	ScheduleType        string            `json:"scheduleType"`
-	CronExpression      string            `json:"cronExpression"`
-	ScheduleInterval    int               `json:"scheduleInterval"`
-	TimeoutSeconds      int               `json:"timeoutSeconds"`
-	Prompt              string            `json:"prompt"`
-	AllowBypass         bool              `json:"allowBypass"`
-	AutonomousMode      bool              `json:"autonomousMode"`
-	MaxRetries          int               `json:"maxRetries"`
-	Model               string            `json:"model"`
-	OverrideRepoCommand string            `json:"overrideRepoCommand"`
-	ClaudeCommand       string            `json:"claudeCommand"`
-	AgentID             string            `json:"agentId"`
-	SuccessPrompt       string            `json:"successPrompt"`
-	FailurePrompt       string            `json:"failurePrompt"`
-	MetadataPrompt      string            `json:"metadataPrompt"`
-	TriagePrompt        string            `json:"triagePrompt"`
-	Interpreter         string            `json:"interpreter"`
-	ScriptContent       string            `json:"scriptContent"`
-	EnvVariables        map[string]string `json:"envVariables"`
-	OnSuccess           []string          `json:"onSuccess"`
-	OnFailure           []string          `json:"onFailure"`
-	WorkspaceID         string            `json:"workspaceId"`
+	Name                string                  `json:"name"`
+	Description         string                  `json:"description"`
+	Type                string                  `json:"type"`
+	WorkingDirectory    string                  `json:"workingDirectory"`
+	ScheduleEnabled     bool                    `json:"scheduleEnabled"`
+	ScheduleType        string                  `json:"scheduleType"`
+	CronExpression      string                  `json:"cronExpression"`
+	ScheduleInterval    int                     `json:"scheduleInterval"`
+	TimeoutSeconds      int                     `json:"timeoutSeconds"`
+	Prompt              string                  `json:"prompt"`
+	AllowBypass         bool                    `json:"allowBypass"`
+	AutonomousMode      bool                    `json:"autonomousMode"`
+	MaxRetries          int                     `json:"maxRetries"`
+	Model               string                  `json:"model"`
+	OverrideRepoCommand string                  `json:"overrideRepoCommand"`
+	ClaudeCommand       string                  `json:"claudeCommand"`
+	AgentID             string                  `json:"agentId"`
+	SuccessPrompt       string                  `json:"successPrompt"`
+	FailurePrompt       string                  `json:"failurePrompt"`
+	MetadataPrompt      string                  `json:"metadataPrompt"`
+	TriagePrompt        string                  `json:"triagePrompt"`
+	Interpreter         string                  `json:"interpreter"`
+	ScriptContent       string                  `json:"scriptContent"`
+	EnvVariables        map[string]string       `json:"envVariables"`
+	// issue #50: typed metadata contract.
+	Inputs              []entity.JobInputSpec  `json:"inputs"`
+	Outputs             []entity.JobOutputSpec `json:"outputs"`
+	OnSuccess           []string                `json:"onSuccess"`
+	OnFailure           []string                `json:"onFailure"`
+	WorkspaceID         string                  `json:"workspaceId"`
 }
 
 // UpdateJobRequest represents the request payload for updating an existing job.
 type UpdateJobRequest struct {
-	ID                  string            `json:"id"`
-	Name                string            `json:"name"`
-	Description         string            `json:"description"`
-	Type                string            `json:"type"`
-	WorkingDirectory    string            `json:"workingDirectory"`
-	ScheduleEnabled     bool              `json:"scheduleEnabled"`
-	ScheduleType        string            `json:"scheduleType"`
-	CronExpression      string            `json:"cronExpression"`
-	ScheduleInterval    int               `json:"scheduleInterval"`
-	TimeoutSeconds      int               `json:"timeoutSeconds"`
-	Prompt              string            `json:"prompt"`
-	AllowBypass         bool              `json:"allowBypass"`
-	AutonomousMode      bool              `json:"autonomousMode"`
-	MaxRetries          int               `json:"maxRetries"`
-	Model               string            `json:"model"`
-	OverrideRepoCommand string            `json:"overrideRepoCommand"`
-	ClaudeCommand       string            `json:"claudeCommand"`
-	AgentID             string            `json:"agentId"`
-	SuccessPrompt       string            `json:"successPrompt"`
-	FailurePrompt       string            `json:"failurePrompt"`
-	MetadataPrompt      string            `json:"metadataPrompt"`
-	TriagePrompt        string            `json:"triagePrompt"`
-	Interpreter         string            `json:"interpreter"`
-	ScriptContent       string            `json:"scriptContent"`
-	EnvVariables        map[string]string `json:"envVariables"`
-	OnSuccess           []string          `json:"onSuccess"`
-	OnFailure           []string          `json:"onFailure"`
-	WorkspaceID         string            `json:"workspaceId"`
+	ID                  string                  `json:"id"`
+	Name                string                  `json:"name"`
+	Description         string                  `json:"description"`
+	Type                string                  `json:"type"`
+	WorkingDirectory    string                  `json:"workingDirectory"`
+	ScheduleEnabled     bool                    `json:"scheduleEnabled"`
+	ScheduleType        string                  `json:"scheduleType"`
+	CronExpression      string                  `json:"cronExpression"`
+	ScheduleInterval    int                     `json:"scheduleInterval"`
+	TimeoutSeconds      int                     `json:"timeoutSeconds"`
+	Prompt              string                  `json:"prompt"`
+	AllowBypass         bool                    `json:"allowBypass"`
+	AutonomousMode      bool                    `json:"autonomousMode"`
+	MaxRetries          int                     `json:"maxRetries"`
+	Model               string                  `json:"model"`
+	OverrideRepoCommand string                  `json:"overrideRepoCommand"`
+	ClaudeCommand       string                  `json:"claudeCommand"`
+	AgentID             string                  `json:"agentId"`
+	SuccessPrompt       string                  `json:"successPrompt"`
+	FailurePrompt       string                  `json:"failurePrompt"`
+	MetadataPrompt      string                  `json:"metadataPrompt"`
+	TriagePrompt        string                  `json:"triagePrompt"`
+	Interpreter         string                  `json:"interpreter"`
+	ScriptContent       string                  `json:"scriptContent"`
+	EnvVariables        map[string]string       `json:"envVariables"`
+	// issue #50: typed metadata contract.
+	Inputs              []entity.JobInputSpec  `json:"inputs"`
+	Outputs             []entity.JobOutputSpec `json:"outputs"`
+	OnSuccess           []string                `json:"onSuccess"`
+	OnFailure           []string                `json:"onFailure"`
+	WorkspaceID         string                  `json:"workspaceId"`
 }
 
 // JobResponse represents the response payload for job data.
 type JobResponse struct {
-	ID                  string            `json:"id"`
-	Name                string            `json:"name"`
-	Description         string            `json:"description"`
-	Type                string            `json:"type"`
-	WorkingDirectory    string            `json:"workingDirectory"`
-	ScheduleEnabled     bool              `json:"scheduleEnabled"`
-	ScheduleType        string            `json:"scheduleType"`
-	CronExpression      string            `json:"cronExpression"`
-	ScheduleInterval    int               `json:"scheduleInterval"`
-	TimeoutSeconds      int               `json:"timeoutSeconds"`
-	Prompt              string            `json:"prompt"`
-	AllowBypass         bool              `json:"allowBypass"`
-	AutonomousMode      bool              `json:"autonomousMode"`
-	MaxRetries          int               `json:"maxRetries"`
-	Model               string            `json:"model"`
-	OverrideRepoCommand string            `json:"overrideRepoCommand"`
-	ClaudeCommand       string            `json:"claudeCommand"`
-	AgentID             string            `json:"agentId"`
-	SuccessPrompt       string            `json:"successPrompt"`
-	FailurePrompt       string            `json:"failurePrompt"`
-	MetadataPrompt      string            `json:"metadataPrompt"`
-	TriagePrompt        string            `json:"triagePrompt"`
-	Interpreter         string            `json:"interpreter"`
-	ScriptContent       string            `json:"scriptContent"`
-	EnvVariables        map[string]string `json:"envVariables"`
-	WorkspaceID         string            `json:"workspaceId"`
-	CreatedAt           string            `json:"createdAt"`
-	UpdatedAt           string            `json:"updatedAt"`
-	OnSuccess           []string          `json:"onSuccess"`
-	OnFailure           []string          `json:"onFailure"`
-	TriggeredBy         []TriggerRef      `json:"triggeredBy"`
+	ID                  string                  `json:"id"`
+	Name                string                  `json:"name"`
+	Description         string                  `json:"description"`
+	Type                string                  `json:"type"`
+	WorkingDirectory    string                  `json:"workingDirectory"`
+	ScheduleEnabled     bool                    `json:"scheduleEnabled"`
+	ScheduleType        string                  `json:"scheduleType"`
+	CronExpression      string                  `json:"cronExpression"`
+	ScheduleInterval    int                     `json:"scheduleInterval"`
+	TimeoutSeconds      int                     `json:"timeoutSeconds"`
+	Prompt              string                  `json:"prompt"`
+	AllowBypass         bool                    `json:"allowBypass"`
+	AutonomousMode      bool                    `json:"autonomousMode"`
+	MaxRetries          int                     `json:"maxRetries"`
+	Model               string                  `json:"model"`
+	OverrideRepoCommand string                  `json:"overrideRepoCommand"`
+	ClaudeCommand       string                  `json:"claudeCommand"`
+	AgentID             string                  `json:"agentId"`
+	SuccessPrompt       string                  `json:"successPrompt"`
+	FailurePrompt       string                  `json:"failurePrompt"`
+	MetadataPrompt      string                  `json:"metadataPrompt"`
+	TriagePrompt        string                  `json:"triagePrompt"`
+	Interpreter         string                  `json:"interpreter"`
+	ScriptContent       string                  `json:"scriptContent"`
+	EnvVariables        map[string]string       `json:"envVariables"`
+	// issue #50: typed metadata contract.
+	Inputs              []entity.JobInputSpec  `json:"inputs"`
+	Outputs             []entity.JobOutputSpec `json:"outputs"`
+	WorkspaceID         string                  `json:"workspaceId"`
+	CreatedAt           string                  `json:"createdAt"`
+	UpdatedAt           string                  `json:"updatedAt"`
+	OnSuccess           []string                `json:"onSuccess"`
+	OnFailure           []string                `json:"onFailure"`
+	TriggeredBy         []TriggerRef            `json:"triggeredBy"`
 }
 
 // TriggerRef describes a trigger relationship with its type.
@@ -120,11 +129,14 @@ type JobRunResponse struct {
 	ModelUsed    string `json:"modelUsed"`
 	DurationMs   int64  `json:"durationMs"`
 	TokensUsed   int    `json:"tokensUsed"`
-	Result          string `json:"result"`
-	ErrorMessage    string `json:"errorMessage"`
-	InjectedContext string `json:"injectedContext"`
-	StartedAt       string `json:"startedAt"`
-	FinishedAt      string `json:"finishedAt"`
+	Result          string         `json:"result"`
+	ErrorMessage    string         `json:"errorMessage"`
+	InjectedContext string         `json:"injectedContext"`
+	// issue #50: produced typed metadata + validation surface.
+	Metadata        map[string]any `json:"metadata"`
+	ValidationError string         `json:"validationError"`
+	StartedAt       string         `json:"startedAt"`
+	FinishedAt      string         `json:"finishedAt"`
 }
 
 // JobResponseFromEntity converts a domain entity to a JobResponse DTO with trigger information.
@@ -170,6 +182,8 @@ func JobResponseFromEntity(job entity.Job, onSuccess []entity.JobTrigger, onFail
 		Interpreter:         job.Interpreter,
 		ScriptContent:       job.ScriptContent,
 		EnvVariables:        job.EnvVariables,
+		Inputs:              job.Inputs,
+		Outputs:             job.Outputs,
 		WorkspaceID:         job.WorkspaceID,
 		CreatedAt:           job.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:           job.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
@@ -221,6 +235,8 @@ func JobRunResponseFromEntity(run entity.JobRun) JobRunResponse {
 		Result:          run.Result,
 		ErrorMessage:    run.ErrorMessage,
 		InjectedContext: run.InjectedContext,
+		Metadata:        run.Metadata,
+		ValidationError: run.ValidationError,
 		StartedAt:       run.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
 		FinishedAt:   finishedAt,
 	}

--- a/internal/integration/mcp/server.go
+++ b/internal/integration/mcp/server.go
@@ -175,6 +175,9 @@ Returns the created job object with the generated ID. Use this ID for run_job, u
 			mcp.WithString("failurePrompt", mcp.Description("How to evaluate failure after the main task completes (max 300 chars). E.g. 'Tests failed, build errors, or no PR created'. Used in the evaluation call. Optional")),
 			mcp.WithString("metadataPrompt", mcp.Description("What structured data to extract for triggered downstream jobs (max 500 chars). E.g. 'Extract PR URL, test count, error summary as JSON'. This metadata is passed as context to downstream triggered jobs, saving tokens vs passing raw output. Optional")),
 			mcp.WithString("triagePrompt", mcp.Description("Criteria for putting the job in 'waiting' state (max 500 chars). E.g. 'Missing credentials, ambiguous requirements, or blocked on external decision'. When set, evaluation can return waiting status to pause the pipeline for human input. Optional")),
+			// issue #50: typed metadata contract
+			mcp.WithString("inputs", mcp.Description(`JSON array of input specs. Each entry: {"key":"...","type":"string|number|boolean|object|array","required":true|false}. Example: [{"key":"linearId","type":"string","required":true}]. The pre-run gate validates incoming metadata against this; missing/wrong-typed required input fails the run before the LLM/bash call. Default: [].`)),
+			mcp.WithString("outputs", mcp.Description(`JSON array of output specs. Each entry: {"key":"...","type":"...","source":"produced"|"passthrough"}. "passthrough" copies the key verbatim from inbound; "produced" extracts from the job's <quant-output>{...} block. Output validation fails closed (no garbage propagation). Default: [].`)),
 			// Bash config
 			mcp.WithString("interpreter", mcp.Description("Shell interpreter for bash jobs: '/bin/bash' (default), '/bin/zsh', 'python3', 'node', etc. The scriptContent is piped to this via stdin")),
 			mcp.WithString("scriptContent", mcp.Description("Script content for bash jobs. Piped to the interpreter via stdin. Exit 0 = success (fires onSuccess triggers), non-zero = failure (fires onFailure triggers). Stdout/stderr are captured as run output")),
@@ -227,6 +230,9 @@ Common workflows:
 			mcp.WithString("failurePrompt", mcp.Description("Failure evaluation criteria (max 300 chars)")),
 			mcp.WithString("metadataPrompt", mcp.Description("Metadata extraction instructions (max 500 chars)")),
 			mcp.WithString("triagePrompt", mcp.Description("Criteria for 'waiting' state (max 500 chars). Set to empty string to disable triage")),
+			// issue #50: typed metadata contract. Presence replaces the array; "" or "[]" clears.
+			mcp.WithString("inputs", mcp.Description(`JSON array of input specs (REPLACES existing). Pass "[]" or "" to clear. Each entry: {"key":"...","type":"string|number|boolean|object|array","required":true|false}.`)),
+			mcp.WithString("outputs", mcp.Description(`JSON array of output specs (REPLACES existing). Pass "[]" or "" to clear. Each entry: {"key":"...","type":"...","source":"produced"|"passthrough"}.`)),
 			mcp.WithString("interpreter", mcp.Description("Script interpreter for bash jobs")),
 			mcp.WithString("scriptContent", mcp.Description("Script content for bash jobs")),
 			mcp.WithString("envVariables", mcp.Description("JSON object of env vars. E.g. '{\"KEY\":\"value\"}'. Replaces existing env vars")),
@@ -269,8 +275,11 @@ To monitor execution:
 - get_run_output(runId) — get the live output (updates while running, polled every few seconds)
 - get_pipeline_status(runId) — trace the full cascade of triggered downstream jobs
 
-The Quant canvas UI shows running jobs with a pulsing green border and highlights the active pipeline path in real-time.`),
+The Quant canvas UI shows running jobs with a pulsing green border and highlights the active pipeline path in real-time.
+
+Optionally pass typed inputs (JSON object) — for a root run these become the run's initial metadata and feed the pre-run validation gate against the job's declared inputs spec.`),
 			mcp.WithString("id", mcp.Required(), mcp.Description("Job ID to run (get from list_jobs)")),
+			mcp.WithString("inputs", mcp.Description(`Optional JSON object of typed inputs. Example: {"linearId":"MAX-86","stack":"backend"}. Default: {} (empty).`)),
 		),
 		s.handleRunJob,
 	)
@@ -987,6 +996,22 @@ func (s *QuantMCPServer) handleCreateJob(_ context.Context, request mcp.CallTool
 		job.AutonomousMode, _ = v.(bool)
 	}
 
+	// issue #50: typed inputs/outputs (JSON-encoded arrays).
+	if v, ok := args["inputs"].(string); ok && v != "" {
+		var specs []entity.JobInputSpec
+		if err := json.Unmarshal([]byte(v), &specs); err != nil {
+			return mcp.NewToolResultError("invalid inputs JSON: " + err.Error()), nil
+		}
+		job.Inputs = specs
+	}
+	if v, ok := args["outputs"].(string); ok && v != "" {
+		var specs []entity.JobOutputSpec
+		if err := json.Unmarshal([]byte(v), &specs); err != nil {
+			return mcp.NewToolResultError("invalid outputs JSON: " + err.Error()), nil
+		}
+		job.Outputs = specs
+	}
+
 	onSuccess := stringSliceArg(args, "onSuccess")
 	onFailure := stringSliceArg(args, "onFailure")
 
@@ -1088,6 +1113,34 @@ func (s *QuantMCPServer) handleUpdateJob(_ context.Context, request mcp.CallTool
 		existing.EnvVariables = mapStringArg(args, "envVariables")
 	}
 
+	// issue #50: typed inputs/outputs (REPLACES existing array on presence).
+	if v, ok := args["inputs"]; ok {
+		raw, _ := v.(string)
+		var specs []entity.JobInputSpec
+		if strings.TrimSpace(raw) != "" {
+			if err := json.Unmarshal([]byte(raw), &specs); err != nil {
+				return mcp.NewToolResultError("invalid inputs JSON: " + err.Error()), nil
+			}
+		}
+		if specs == nil {
+			specs = []entity.JobInputSpec{}
+		}
+		existing.Inputs = specs
+	}
+	if v, ok := args["outputs"]; ok {
+		raw, _ := v.(string)
+		var specs []entity.JobOutputSpec
+		if strings.TrimSpace(raw) != "" {
+			if err := json.Unmarshal([]byte(raw), &specs); err != nil {
+				return mcp.NewToolResultError("invalid outputs JSON: " + err.Error()), nil
+			}
+		}
+		if specs == nil {
+			specs = []entity.JobOutputSpec{}
+		}
+		existing.Outputs = specs
+	}
+
 	// Only update triggers if explicitly provided — nil means "don't change"
 	onSuccess := stringSliceArg(args, "onSuccess")
 	onFailure := stringSliceArg(args, "onFailure")
@@ -1132,7 +1185,18 @@ func (s *QuantMCPServer) handleRunJob(_ context.Context, request mcp.CallToolReq
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	run, err := s.jobManager.RunJob(id, "")
+	// issue #50: optional typed inputs (JSON object string).
+	var inputs map[string]any
+	if v, ok := request.GetArguments()["inputs"]; ok {
+		raw, _ := v.(string)
+		if strings.TrimSpace(raw) != "" {
+			if err := json.Unmarshal([]byte(raw), &inputs); err != nil {
+				return mcp.NewToolResultError("invalid inputs JSON: " + err.Error()), nil
+			}
+		}
+	}
+
+	run, err := s.jobManager.RunJob(id, "", inputs)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -2433,6 +2497,18 @@ func jobToMap(job *entity.Job) map[string]any {
 	if job.EnvVariables != nil {
 		m["envVariables"] = job.EnvVariables
 	}
+	// issue #50: always emit the typed contract (empty array if unset) so
+	// clients always see the contract field shape.
+	if job.Inputs != nil {
+		m["inputs"] = job.Inputs
+	} else {
+		m["inputs"] = []entity.JobInputSpec{}
+	}
+	if job.Outputs != nil {
+		m["outputs"] = job.Outputs
+	} else {
+		m["outputs"] = []entity.JobOutputSpec{}
+	}
 	return m
 }
 
@@ -2454,9 +2530,20 @@ func runToMap(run *entity.JobRun) map[string]any {
 		"errorMessage":    run.ErrorMessage,
 		"injectedContext": run.InjectedContext,
 		"startedAt":       run.StartedAt,
+		// issue #50: typed metadata + validation surface.
+		"metadata":        ensureMap(run.Metadata),
+		"validationError": run.ValidationError,
 	}
 	if run.FinishedAt != nil {
 		m["finishedAt"] = *run.FinishedAt
+	}
+	return m
+}
+
+// ensureMap returns m or an empty map so the JSON shape is always an object.
+func ensureMap(m map[string]any) map[string]any {
+	if m == nil {
+		return map[string]any{}
 	}
 	return m
 }

--- a/internal/integration/persistence/dto/job.go
+++ b/internal/integration/persistence/dto/job.go
@@ -38,6 +38,9 @@ type JobRow struct {
 	ScriptContent       string
 	EnvVariables        string // JSON
 	WorkspaceID         string
+	// issue #50: typed metadata contract (JSON-encoded arrays of specs).
+	Inputs              string
+	Outputs             string
 	CreatedAt           string
 	UpdatedAt           string
 	LastRunAt           sql.NullString
@@ -57,6 +60,15 @@ func (r JobRow) ToEntity() entity.Job {
 	envVars := make(map[string]string)
 	if r.EnvVariables != "" {
 		_ = json.Unmarshal([]byte(r.EnvVariables), &envVars)
+	}
+
+	var inputs []entity.JobInputSpec
+	if r.Inputs != "" {
+		_ = json.Unmarshal([]byte(r.Inputs), &inputs)
+	}
+	var outputs []entity.JobOutputSpec
+	if r.Outputs != "" {
+		_ = json.Unmarshal([]byte(r.Outputs), &outputs)
 	}
 
 	var lastRunAt *time.Time
@@ -93,6 +105,8 @@ func (r JobRow) ToEntity() entity.Job {
 		ScriptContent:       r.ScriptContent,
 		EnvVariables:        envVars,
 		WorkspaceID:         r.WorkspaceID,
+		Inputs:              inputs,
+		Outputs:             outputs,
 		CreatedAt:           createdAt,
 		UpdatedAt:           updatedAt,
 		LastRunAt:           lastRunAt,
@@ -114,6 +128,15 @@ func JobRowFromEntity(job entity.Job) JobRow {
 	envJSON, _ := json.Marshal(job.EnvVariables)
 	if job.EnvVariables == nil {
 		envJSON = []byte("{}")
+	}
+
+	inputsJSON, _ := json.Marshal(job.Inputs)
+	if job.Inputs == nil {
+		inputsJSON = []byte("[]")
+	}
+	outputsJSON, _ := json.Marshal(job.Outputs)
+	if job.Outputs == nil {
+		outputsJSON = []byte("[]")
 	}
 
 	scheduleEnabled := 0
@@ -157,6 +180,8 @@ func JobRowFromEntity(job entity.Job) JobRow {
 		ScriptContent:       job.ScriptContent,
 		EnvVariables:        string(envJSON),
 		WorkspaceID:         job.WorkspaceID,
+		Inputs:              string(inputsJSON),
+		Outputs:             string(outputsJSON),
 		CreatedAt:           job.CreatedAt.Format(time.RFC3339),
 		UpdatedAt:           job.UpdatedAt.Format(time.RFC3339),
 		LastRunAt:           lastRunAt,

--- a/internal/integration/persistence/dto/job_run.go
+++ b/internal/integration/persistence/dto/job_run.go
@@ -3,6 +3,7 @@ package dto
 
 import (
 	"database/sql"
+	"encoding/json"
 	"time"
 
 	"quant/internal/domain/entity"
@@ -22,6 +23,10 @@ type JobRunRow struct {
 	Result          string
 	ErrorMessage    string
 	InjectedContext string
+	// issue #50: produced metadata (after sentinel extraction + passthrough)
+	// and validation failure surface for the UI.
+	Metadata        string // JSON object
+	ValidationError string
 	StartedAt       string
 	FinishedAt   sql.NullString
 }
@@ -46,6 +51,11 @@ func (r JobRunRow) ToEntity() entity.JobRun {
 		sessionID = r.SessionID.String
 	}
 
+	var metadata map[string]any
+	if r.Metadata != "" {
+		_ = json.Unmarshal([]byte(r.Metadata), &metadata)
+	}
+
 	return entity.JobRun{
 		ID:           r.ID,
 		JobID:        r.JobID,
@@ -59,6 +69,8 @@ func (r JobRunRow) ToEntity() entity.JobRun {
 		Result:          r.Result,
 		ErrorMessage:    r.ErrorMessage,
 		InjectedContext: r.InjectedContext,
+		Metadata:        metadata,
+		ValidationError: r.ValidationError,
 		StartedAt:       startedAt,
 		FinishedAt:      finishedAt,
 	}
@@ -81,6 +93,11 @@ func JobRunRowFromEntity(run entity.JobRun) JobRunRow {
 		sessionID = sql.NullString{String: run.SessionID, Valid: true}
 	}
 
+	metaJSON, _ := json.Marshal(run.Metadata)
+	if run.Metadata == nil {
+		metaJSON = []byte("{}")
+	}
+
 	return JobRunRow{
 		ID:            run.ID,
 		JobID:         run.JobID,
@@ -94,6 +111,8 @@ func JobRunRowFromEntity(run entity.JobRun) JobRunRow {
 		Result:          run.Result,
 		ErrorMessage:    run.ErrorMessage,
 		InjectedContext: run.InjectedContext,
+		Metadata:        string(metaJSON),
+		ValidationError: run.ValidationError,
 		StartedAt:       run.StartedAt.Format(time.RFC3339),
 		FinishedAt:   finishedAt,
 	}

--- a/internal/integration/persistence/job.go
+++ b/internal/integration/persistence/job.go
@@ -24,12 +24,12 @@ func NewJobPersistence(db *sql.DB) adapter.JobPersistence {
 const jobColumns = `id, name, description, type, working_directory, schedule_enabled, schedule_type, cron_expression,
 		schedule_interval, schedule_start_time, timeout_seconds, prompt, allow_bypass, autonomous_mode,
 		max_retries, model, override_repo_command, claude_command, agent_id, success_prompt, failure_prompt, metadata_prompt, triage_prompt,
-		interpreter, script_content, env_variables, workspace_id, created_at, updated_at, last_run_at`
+		interpreter, script_content, env_variables, workspace_id, inputs, outputs, created_at, updated_at, last_run_at`
 
 const jobTriggerColumns = `id, source_job_id, target_job_id, trigger_on`
 
 const jobRunColumns = `id, job_id, status, triggered_by, correlation_id, session_id, model_used, duration_ms, tokens_used, result,
-		error_message, injected_context, started_at, finished_at`
+		error_message, injected_context, metadata, validation_error, started_at, finished_at`
 
 func scanJobRow(scanner interface{ Scan(...any) error }) (pdto.JobRow, error) {
 	var row pdto.JobRow
@@ -41,7 +41,7 @@ func scanJobRow(scanner interface{ Scan(...any) error }) (pdto.JobRow, error) {
 		&row.MaxRetries, &row.Model, &row.OverrideRepoCommand, &row.ClaudeCommand,
 		&row.AgentID, &row.SuccessPrompt, &row.FailurePrompt, &row.MetadataPrompt, &row.TriagePrompt,
 		&row.Interpreter, &row.ScriptContent, &row.EnvVariables,
-		&row.WorkspaceID, &row.CreatedAt, &row.UpdatedAt, &row.LastRunAt,
+		&row.WorkspaceID, &row.Inputs, &row.Outputs, &row.CreatedAt, &row.UpdatedAt, &row.LastRunAt,
 	)
 	return row, err
 }
@@ -59,7 +59,7 @@ func scanJobRunRow(scanner interface{ Scan(...any) error }) (pdto.JobRunRow, err
 	err := scanner.Scan(
 		&row.ID, &row.JobID, &row.Status, &row.TriggeredBy, &row.CorrelationID, &row.SessionID,
 		&row.ModelUsed, &row.DurationMs, &row.TokensUsed, &row.Result,
-		&row.ErrorMessage, &row.InjectedContext, &row.StartedAt, &row.FinishedAt,
+		&row.ErrorMessage, &row.InjectedContext, &row.Metadata, &row.ValidationError, &row.StartedAt, &row.FinishedAt,
 	)
 	return row, err
 }
@@ -141,8 +141,8 @@ func (p *jobPersistence) SaveJob(job entity.Job) error {
 		cron_expression, schedule_interval, schedule_start_time, timeout_seconds, prompt, allow_bypass,
 		autonomous_mode, max_retries, model, override_repo_command, claude_command, agent_id,
 		success_prompt, failure_prompt, metadata_prompt, triage_prompt,
-		interpreter, script_content, env_variables, workspace_id, created_at, updated_at, last_run_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		interpreter, script_content, env_variables, workspace_id, inputs, outputs, created_at, updated_at, last_run_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	_, err := p.db.Exec(query,
 		row.ID, row.Name, row.Description, row.Type, row.WorkingDirectory,
@@ -152,7 +152,7 @@ func (p *jobPersistence) SaveJob(job entity.Job) error {
 		row.MaxRetries, row.Model, row.OverrideRepoCommand, row.ClaudeCommand,
 		row.AgentID, row.SuccessPrompt, row.FailurePrompt, row.MetadataPrompt, row.TriagePrompt,
 		row.Interpreter, row.ScriptContent, row.EnvVariables,
-		row.WorkspaceID, row.CreatedAt, row.UpdatedAt, row.LastRunAt,
+		row.WorkspaceID, row.Inputs, row.Outputs, row.CreatedAt, row.UpdatedAt, row.LastRunAt,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to save job: %w", err)
@@ -171,7 +171,7 @@ func (p *jobPersistence) UpdateJob(job entity.Job) error {
 		autonomous_mode = ?, max_retries = ?, model = ?, override_repo_command = ?,
 		claude_command = ?, agent_id = ?, success_prompt = ?, failure_prompt = ?, metadata_prompt = ?, triage_prompt = ?,
 		interpreter = ?, script_content = ?, env_variables = ?,
-		workspace_id = ?, updated_at = ?, last_run_at = ? WHERE id = ?`
+		workspace_id = ?, inputs = ?, outputs = ?, updated_at = ?, last_run_at = ? WHERE id = ?`
 
 	result, err := p.db.Exec(query,
 		row.Name, row.Description, row.Type, row.WorkingDirectory,
@@ -180,7 +180,7 @@ func (p *jobPersistence) UpdateJob(job entity.Job) error {
 		row.AutonomousMode, row.MaxRetries, row.Model, row.OverrideRepoCommand,
 		row.ClaudeCommand, row.AgentID, row.SuccessPrompt, row.FailurePrompt, row.MetadataPrompt, row.TriagePrompt,
 		row.Interpreter, row.ScriptContent, row.EnvVariables,
-		row.WorkspaceID, row.UpdatedAt, row.LastRunAt, row.ID,
+		row.WorkspaceID, row.Inputs, row.Outputs, row.UpdatedAt, row.LastRunAt, row.ID,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update job: %w", err)
@@ -419,13 +419,13 @@ func (p *jobPersistence) SaveJobRun(run entity.JobRun) error {
 	row := pdto.JobRunRowFromEntity(run)
 
 	query := `INSERT INTO job_runs (id, job_id, status, triggered_by, correlation_id, session_id, model_used, duration_ms, tokens_used,
-		result, error_message, injected_context, started_at, finished_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		result, error_message, injected_context, metadata, validation_error, started_at, finished_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	_, err := p.db.Exec(query,
 		row.ID, row.JobID, row.Status, row.TriggeredBy, row.CorrelationID, row.SessionID,
 		row.ModelUsed, row.DurationMs, row.TokensUsed, row.Result,
-		row.ErrorMessage, row.InjectedContext, row.StartedAt, row.FinishedAt,
+		row.ErrorMessage, row.InjectedContext, row.Metadata, row.ValidationError, row.StartedAt, row.FinishedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to save job run: %w", err)
@@ -440,12 +440,12 @@ func (p *jobPersistence) UpdateJobRun(run entity.JobRun) error {
 
 	query := `UPDATE job_runs SET job_id = ?, status = ?, triggered_by = ?, correlation_id = ?, session_id = ?,
 		model_used = ?, duration_ms = ?, tokens_used = ?, result = ?, error_message = ?,
-		injected_context = ?, started_at = ?, finished_at = ? WHERE id = ?`
+		injected_context = ?, metadata = ?, validation_error = ?, started_at = ?, finished_at = ? WHERE id = ?`
 
 	result, err := p.db.Exec(query,
 		row.JobID, row.Status, row.TriggeredBy, row.CorrelationID, row.SessionID,
 		row.ModelUsed, row.DurationMs, row.TokensUsed, row.Result, row.ErrorMessage,
-		row.InjectedContext, row.StartedAt, row.FinishedAt, row.ID,
+		row.InjectedContext, row.Metadata, row.ValidationError, row.StartedAt, row.FinishedAt, row.ID,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update job run: %w", err)


### PR DESCRIPTION
Layer a typed metadata contract on top of the existing workflow engine (correlation_id, injected_context, AdvancePipeline) so metadata stops getting lost between pipeline steps. Closes #50; the correlation/context plumbing from #43 / PR #46 is reused as-is.

Engine
- jobs.inputs / jobs.outputs JSON columns hold typed schemas (JobInputSpec / JobOutputSpec) declared per job.
- job_runs.metadata holds the produced outputs after sentinel extraction
  + passthrough enforcement; job_runs.validation_error surfaces gate or output-validation failures.
- Pre-run validation gate (hard fail) in executeWithRetries: missing or wrong-typed required input fails the run before any LLM/bash invocation, and still fires onFailure triggers so triage cascades fire.
- <quant-output>{...}</quant-output> sentinel extraction (last block wins) replaces the legacy "\n\n--- metadata ---\n" string suffix on run.Result. Passthrough outputs are copied verbatim from inbound and cannot be overwritten by the job. Output validation fails closed — no garbage metadata propagates downstream.
- Self-correction loop: when a Claude job runs but botches its declared output contract (missing/wrong-typed produced key or malformed sentinel JSON), the run no longer fails closed immediately. While the retry budget allows, it re-prompts the agent with the exact validation errors and a directive to re-emit a valid <quant-output> block, then retries; it fails closed only once attempts are exhausted. Input-gate failures and bash jobs still fail closed (the agent cannot fix upstream data, and re-running a deterministic script changes nothing).
- fireTriggers + RerunJob source structured metadata from the parent run's typed Metadata column instead of parsing the suffix on Result; the trigger-context string still flows through the existing triggerCtx / InjectedContext / QUANT_TRIGGER_CONTEXT plumbing.
- RunJob signature: inputs map[string]any added before the variadic correlationID. For a root run, inputs become the run's initial Metadata (the gate validates against them); triggered runs read the parent's Metadata via TriggeredBy.
- RunJob now hands a private copy of the entity.JobRun to the async execute goroutine instead of sharing the same value with the synchronous caller. The previous code returned &run while the goroutine mutated Status/Metadata/FinishedAt on that same pointer — a pre-existing data race surfaced by the -race E2E run. Durable state still flows through the DB so the copies never diverge.

MCP
- create_job / update_job carry inputs/outputs (JSON-encoded arrays).
- run_job accepts an optional inputs JSON object.
- jobToMap emits inputs/outputs; runToMap emits metadata / validationError.

Misc
- internal/infra/paths/paths.go: QUANT_HOME / QUANT_SKIP_CLAUDE_CONFIG for test isolation.
- frontend/src/types.ts: JobInputSpec / JobOutputSpec; Job adds inputs/outputs; JobRun adds metadata / validationError.
- Makefile: `test` target.

Tests
- Unit tests for the input validator, the sentinel extractor, and the output-contract self-correction prompt.
- internal/e2e: in-process E2E that boots the full stack with an HOME-isolated temp SQLite, starts the real MCP server, and drives it through the mark3labs/mcp-go streamable HTTP client. Covers the typed-contract bash chain (gate, sentinel last-block-wins, passthrough integrity, type fidelity, correlation propagation), input-gate negatives with onFailure triage, and the Claude self-correction loop (success after one retry with the corrective feedback in the prompt; fail-closed when the retry budget is exhausted) via a fake claude script that emits stream-json. Safety: every test t.Setenv("HOME", t.TempDir()) before opening SQLite, and asserts the DB lands under the temp HOME — real ~/.quant is never touched.

UI contract tab (CreateJobModal) and run-detail typed-metadata rendering deliberately deferred to a follow-up PR — engine ships first; MCP-driven flows already work end-to-end against this branch.