### PR TITLE
fix: restore SchemaField type so the frontend compiles

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -141,6 +141,16 @@ export interface JobOutputSpec {
   source: "produced" | "passthrough";
 }
 
+// Unified row shape used by SchemaFieldEditor for both inputs (required) and
+// outputs (source). type/source are broadened to string because the editor's
+// <select> onChange handlers assign raw e.target.value.
+export interface SchemaField {
+  key: string;
+  type: string;
+  required?: boolean;
+  source?: string;
+}
+
 export interface TriggerRef {
   jobId: string;
   triggerOn: "success" | "failure";


### PR DESCRIPTION
Hotfix for v3.1.19 which fails `brew install` (the Homebrew formula runs `tsc && vite build`). SchemaFieldEditor.tsx imports a SchemaField type that was dropped from types.ts during the issue-50 rescope. Restores the unified SchemaField interface. Verified locally: `npm run build` passes.