### PR TITLE
feat(issue-50): contract setup tab in job editor

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,15 @@
 {
   "entries": [
     {
+      "version": "v3.1.22",
+      "date": "2026-05-29",
+      "changes": {
+        "features": [
+          "add a contract tab to the job editor for declaring typed inputs/outputs (issue #50 metadata pipeline)"
+        ]
+      }
+    },
+    {
       "version": "v3.1.21",
       "date": "2026-05-29",
       "changes": {

--- a/frontend/src/components/CreateJobModal.tsx
+++ b/frontend/src/components/CreateJobModal.tsx
@@ -1,12 +1,38 @@
 import { useState, useRef, useEffect } from "react";
-import type { Job, JobType, CreateJobRequest, UpdateJobRequest, ScheduleType, Agent } from "../types";
+import type { Job, JobType, CreateJobRequest, UpdateJobRequest, ScheduleType, Agent, SchemaField, JobInputSpec, JobOutputSpec } from "../types";
 import * as api from "../api";
+import { SchemaFieldEditor } from "./SchemaFieldEditor";
 
 const MODEL_OPTIONS = ["cli default", "claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5-20251001"];
 const INTERPRETER_OPTIONS = ["/bin/bash", "/bin/sh", "/bin/zsh", "python3"];
 const SCHEDULE_UNIT_OPTIONS = ["minutes", "hours", "days"];
 
-type TabKey = "general" | "schedule" | "session" | "script";
+const SPEC_TYPES = ["string", "number", "boolean", "object", "array"] as const;
+type SpecType = (typeof SPEC_TYPES)[number];
+
+// The editor stores rows with loosely-typed `type`/`source` (raw <select> values);
+// the API contract is strict. Coerce + drop blank-key rows on submit (issue #50).
+function coerceType(t: string): SpecType {
+  return (SPEC_TYPES as readonly string[]).includes(t) ? (t as SpecType) : "string";
+}
+
+function toInputSpecs(rows: SchemaField[]): JobInputSpec[] {
+  return rows
+    .filter((r) => r.key.trim())
+    .map((r) => ({ key: r.key.trim(), type: coerceType(r.type), required: !!r.required }));
+}
+
+function toOutputSpecs(rows: SchemaField[]): JobOutputSpec[] {
+  return rows
+    .filter((r) => r.key.trim())
+    .map((r) => ({
+      key: r.key.trim(),
+      type: coerceType(r.type),
+      source: r.source === "produced" ? "produced" : "passthrough",
+    }));
+}
+
+type TabKey = "general" | "schedule" | "session" | "script" | "contract";
 
 interface Props {
   jobs: Job[];
@@ -86,6 +112,10 @@ export function CreateJobModal({ jobs, agents, editJob, onSubmit, onCancel }: Pr
   const [activeTab, setActiveTab] = useState<TabKey>("general");
   const [scheduleUnit, setScheduleUnit] = useState("minutes");
 
+  // issue #50: typed metadata contract rows (loose-typed for the editor).
+  const [inputs, setInputs] = useState<SchemaField[]>(editJob?.inputs ?? []);
+  const [outputs, setOutputs] = useState<SchemaField[]>(editJob?.outputs ?? []);
+
   // Trigger dropdowns
   const [successDropdownOpen, setSuccessDropdownOpen] = useState(false);
   const [failureDropdownOpen, setFailureDropdownOpen] = useState(false);
@@ -124,7 +154,12 @@ export function CreateJobModal({ jobs, agents, editJob, onSubmit, onCancel }: Pr
         : scheduleUnit === "days"
           ? form.scheduleInterval * 1440
           : form.scheduleInterval;
-    const req: CreateJobRequest = { ...form, scheduleInterval: intervalSeconds };
+    const req: CreateJobRequest = {
+      ...form,
+      scheduleInterval: intervalSeconds,
+      inputs: toInputSpecs(inputs),
+      outputs: toOutputSpecs(outputs),
+    };
     if (isEdit && editJob) {
       onSubmit({ ...req, id: editJob.id } as UpdateJobRequest);
     } else {
@@ -145,6 +180,7 @@ export function CreateJobModal({ jobs, agents, editJob, onSubmit, onCancel }: Pr
     { key: "general", label: "general" },
     { key: "schedule", label: "schedule" },
     { key: form.type === "claude" ? "session" : "script", label: form.type === "claude" ? "session" : "script" },
+    { key: "contract", label: "contract" },
   ];
 
   const availableJobsForSuccess = jobs.filter(
@@ -826,6 +862,43 @@ export function CreateJobModal({ jobs, agents, editJob, onSubmit, onCancel }: Pr
                     + add
                   </button>
                 </div>
+              </div>
+            </>
+          )}
+
+          {/* TAB: Contract (issue #50 typed metadata) */}
+          {activeTab === "contract" && (
+            <>
+              <span
+                style={{
+                  color: "var(--q-fg-muted)",
+                  fontSize: 9,
+                  fontFamily: "'JetBrains Mono', monospace",
+                }}
+              >
+                # inputs — keys consumed from upstream metadata (required ones gate the run)
+              </span>
+              <SchemaFieldEditor kind="input" fields={inputs} onChange={setInputs} />
+
+              <div
+                style={{
+                  borderTop: "1px solid var(--q-border)",
+                  paddingTop: 12,
+                  marginTop: 4,
+                }}
+              >
+                <span
+                  style={{
+                    color: "var(--q-fg-muted)",
+                    fontSize: 9,
+                    fontFamily: "'JetBrains Mono', monospace",
+                    display: "block",
+                    marginBottom: 8,
+                  }}
+                >
+                  # outputs — keys this job produces or forwards (passthrough)
+                </span>
+                <SchemaFieldEditor kind="output" fields={outputs} onChange={setOutputs} />
               </div>
             </>
           )}

--- a/frontend/src/components/SchemaFieldEditor.tsx
+++ b/frontend/src/components/SchemaFieldEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { SchemaField } from "../types";
 
 const TYPES = ["string", "number", "boolean", "object", "array"] as const;
@@ -13,8 +13,9 @@ interface Props {
 
 /**
  * SchemaFieldEditor — per-row editor for the `inputs` or `outputs` array on
- * a Job. Modelled after the Shortcuts editor in Settings.tsx; uses the same
- * JetBrains Mono / lowercase aesthetic and css vars.
+ * a Job. Uses quant's custom controls (FieldSelect / FieldToggle below) rather
+ * than native <select>/<checkbox> so the editor matches the rest of the modal's
+ * JetBrains Mono / lowercase / accent aesthetic.
  *
  * For `kind="input"` the row shows: key | type | required toggle | x
  * For `kind="output"` the row shows: key | type | source select   | x
@@ -53,12 +54,6 @@ export function SchemaFieldEditor({ kind, fields, onChange }: Props) {
     outline: "none",
   };
 
-  const selectStyle: React.CSSProperties = {
-    ...inputStyle,
-    color: "var(--q-accent)",
-    cursor: "pointer",
-  };
-
   return (
     <div
       data-testid={`schema-editor-${kind}`}
@@ -92,74 +87,67 @@ export function SchemaFieldEditor({ kind, fields, onChange }: Props) {
             onFocus={(e) => (e.currentTarget.style.borderColor = "var(--q-accent)")}
             onBlur={(e) => (e.currentTarget.style.borderColor = "var(--q-border)")}
           />
-          <select
-            data-testid={`schema-field-type-${i}`}
+
+          <FieldSelect
+            testId={`schema-field-type-${i}`}
             value={f.type || "string"}
-            onChange={(e) => updateRow(i, { type: e.target.value })}
-            style={{ ...selectStyle, width: 100 }}
-          >
-            {TYPES.map((t) => (
-              <option key={t} value={t}>
-                {t}
-              </option>
-            ))}
-          </select>
+            options={TYPES}
+            onChange={(v) => updateRow(i, { type: v })}
+            width={92}
+          />
 
           {kind === "input" && (
-            <label
-              data-testid={`schema-field-required-${i}`}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 4,
-                fontFamily: font,
-                fontSize: 11,
-                color: "var(--q-fg-secondary)",
-                cursor: "pointer",
-                userSelect: "none",
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={!!f.required}
-                onChange={(e) => updateRow(i, { required: e.target.checked })}
-              />
-              required
-            </label>
+            <FieldToggle
+              testId={`schema-field-required-${i}`}
+              label="required"
+              checked={!!f.required}
+              onChange={(v) => updateRow(i, { required: v })}
+            />
           )}
 
           {kind === "output" && (
-            <select
-              data-testid={`schema-field-source-${i}`}
+            <FieldSelect
+              testId={`schema-field-source-${i}`}
               value={f.source || "passthrough"}
-              onChange={(e) => updateRow(i, { source: e.target.value })}
-              style={{ ...selectStyle, width: 120 }}
-            >
-              {SOURCES.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
-            </select>
+              options={SOURCES}
+              onChange={(v) => updateRow(i, { source: v })}
+              width={116}
+            />
           )}
 
           <button
             type="button"
             data-testid={`schema-field-delete-${i}`}
             onClick={() => removeRow(i)}
+            title="delete field"
             style={{
-              color: "var(--q-error)",
-              fontSize: 11,
-              fontFamily: font,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 24,
+              height: 24,
+              flexShrink: 0,
+              color: "var(--q-fg-secondary)",
               background: "none",
               border: "none",
               cursor: "pointer",
-              padding: "0 6px",
             }}
-            onMouseEnter={(e) => (e.currentTarget.style.opacity = "0.7")}
-            onMouseLeave={(e) => (e.currentTarget.style.opacity = "1")}
+            onMouseEnter={(e) => (e.currentTarget.style.color = "var(--q-error)")}
+            onMouseLeave={(e) => (e.currentTarget.style.color = "var(--q-fg-secondary)")}
           >
-            x
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="3 6 5 6 21 6" />
+              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+            </svg>
           </button>
         </div>
       ))}
@@ -204,6 +192,170 @@ export function SchemaFieldEditor({ kind, fields, onChange }: Props) {
           + add field
         </button>
       </div>
+    </div>
+  );
+}
+
+// --- Sub-components (mirror CreateJobModal's MiniSelect / ToggleSwitch so the
+// contract editor uses quant's controls instead of native form elements) ---
+
+function FieldSelect({
+  testId,
+  value,
+  options,
+  onChange,
+  width,
+}: {
+  testId: string;
+  value: string;
+  options: readonly string[];
+  onChange: (v: string) => void;
+  width: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [open]);
+
+  return (
+    <div ref={ref} style={{ position: "relative", width, flexShrink: 0 }}>
+      <button
+        type="button"
+        data-testid={testId}
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          width,
+          height: 26,
+          backgroundColor: "var(--q-bg-hover)",
+          border: `1px solid ${open ? "var(--q-accent)" : "var(--q-border)"}`,
+          color: "var(--q-accent)",
+          fontSize: 11,
+          fontFamily: font,
+          padding: "0 8px",
+          textAlign: "left",
+          cursor: "pointer",
+          backgroundImage:
+            "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M0 2l4 4 4-4' fill='none' stroke='%236B7280' stroke-width='1.5'/%3E%3C/svg%3E\")",
+          backgroundRepeat: "no-repeat",
+          backgroundPosition: "right 8px center",
+        }}
+      >
+        {value}
+      </button>
+      {open && (
+        <div
+          style={{
+            position: "absolute",
+            top: 28,
+            left: 0,
+            zIndex: 60,
+            backgroundColor: "var(--q-bg)",
+            border: "1px solid var(--q-border)",
+            width: "100%",
+          }}
+        >
+          {options.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              data-testid={`${testId}-opt-${opt}`}
+              onClick={() => {
+                onChange(opt);
+                setOpen(false);
+              }}
+              className="w-full flex items-center text-left"
+              style={{
+                height: 26,
+                padding: "0 8px",
+                gap: 6,
+                fontFamily: font,
+                fontSize: 11,
+                color: opt === value ? "var(--q-accent)" : "var(--q-fg-dimmed)",
+                backgroundColor: opt === value ? "var(--q-bg-hover)" : "transparent",
+                border: "none",
+                cursor: "pointer",
+              }}
+              onMouseEnter={(e) => {
+                if (opt !== value)
+                  e.currentTarget.style.backgroundColor = "var(--q-bg-hover)";
+              }}
+              onMouseLeave={(e) => {
+                if (opt !== value)
+                  e.currentTarget.style.backgroundColor = "transparent";
+              }}
+            >
+              <span style={{ color: "var(--q-accent)", flexShrink: 0 }}>~</span>
+              <span>{opt}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FieldToggle({
+  testId,
+  label,
+  checked,
+  onChange,
+}: {
+  testId: string;
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center" style={{ gap: 6, flexShrink: 0 }}>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        data-testid={testId}
+        onClick={() => onChange(!checked)}
+        style={{
+          width: 32,
+          height: 18,
+          borderRadius: 9,
+          backgroundColor: checked ? "var(--q-accent)" : "var(--q-border)",
+          border: "none",
+          cursor: "pointer",
+          position: "relative",
+          transition: "background-color 150ms",
+          flexShrink: 0,
+        }}
+      >
+        <div
+          style={{
+            width: 14,
+            height: 14,
+            borderRadius: 7,
+            backgroundColor: "var(--q-fg)",
+            position: "absolute",
+            top: 2,
+            left: checked ? 16 : 2,
+            transition: "left 150ms",
+          }}
+        />
+      </button>
+      <span
+        style={{
+          fontFamily: font,
+          fontSize: 11,
+          color: "var(--q-fg-secondary)",
+          userSelect: "none",
+        }}
+      >
+        {label}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Adds a **contract** tab to the job create/edit modal so users can declare typed `inputs`/`outputs` from the GUI (issue #50 metadata pipeline follow-up — backend already shipped).

- `CreateJobModal`: new contract tab (claude & bash), `inputs`/`outputs` state, `toInputSpecs`/`toOutputSpecs` coercion (drops blank-key rows, narrows loose type/source to the strict union) feeding create/update payloads.
- `SchemaFieldEditor`: redesigned to use quant's custom controls — accent dropdowns with chevron (type/source), green pill toggle (required), and the workspace trash-bin icon for deletion — instead of native `<select>`/checkbox/`x`.
- `changelog.json`: v3.1.22 entry.

## E2E (Playwright against `wails dev`, isolated HOME)
- Contract tab renders for new + edit jobs ✓
- Authored `linearId` (string, required) + `priority` (number) inputs and `prUrl` (string, produced) output → persisted to DB **exactly** (coercion verified) ✓
- Round-trips back into edit mode with all values + toggle/dropdown states ✓
- Running with the required `linearId` absent → run **failed** with `missing required input "linearId"` — the UI-authored contract is enforced end-to-end ✓

## Gates
- `npm run build` (tsc + vite) ✓ · `go build ./...` ✓ (no Go changes)