### PR TITLE
feat(issue-50): feed validation gate from run_job_with_context via typed inputs

### DIFF
--- a/internal/application/adapter/job_manager.go
+++ b/internal/application/adapter/job_manager.go
@@ -22,7 +22,13 @@ type JobManager interface {
 	//     nil here is the right default for trigger-paths.
 	//   - correlationID: upstream's pipeline-wide id (variadic, optional).
 	RunJob(jobID string, triggeredByRunID string, inputs map[string]any, correlationID ...string) (*entity.JobRun, error)
-	RunJobWithContext(jobID string, context string) (*entity.JobRun, error)
+	// RunJobWithContext starts a ROOT run with prompt-injected context.
+	//   - context: freeform string prepended to the prompt only (does NOT feed
+	//     the validation gate).
+	//   - inputs: typed metadata that DOES feed the pre-run validation gate,
+	//     same semantics as RunJob's inputs for a root run. Pass nil when the
+	//     target job declares no required inputs.
+	RunJobWithContext(jobID string, context string, inputs map[string]any) (*entity.JobRun, error)
 	RerunJob(jobID string, originalRunID string) (*entity.JobRun, error)
 	CancelRun(runID string) error
 	GetRun(runID string) (*entity.JobRun, error)

--- a/internal/application/service/job_manager.go
+++ b/internal/application/service/job_manager.go
@@ -333,8 +333,14 @@ func (s *jobManagerService) RunJob(jobID string, triggeredByRunID string, inputs
 // RunJobWithContext starts a new run for a job, injecting arbitrary context into its prompt.
 // The context string is prepended to the job's prompt in the same format as trigger context,
 // so existing jobs that parse TASK_IDENTIFIER= etc. work without modification.
-func (s *jobManagerService) RunJobWithContext(jobID string, context string) (*entity.JobRun, error) {
-	run, err := s.RunJob(jobID, "", nil)
+//
+// issue #50: inputs carries typed metadata that feeds the pre-run validation
+// gate (a root run pre-seeds run.Metadata from it; see RunJob). This is what
+// lets a job entered OUTSIDE a trigger edge — orchestrator kickoff, retry,
+// self-heal re-fire — satisfy `required` inputs. The context arg remains
+// prompt-only and never reaches the gate. Pass nil inputs for prompt-only use.
+func (s *jobManagerService) RunJobWithContext(jobID string, context string, inputs map[string]any) (*entity.JobRun, error) {
+	run, err := s.RunJob(jobID, "", inputs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/e2e/context_inputs_test.go
+++ b/internal/e2e/context_inputs_test.go
@@ -1,0 +1,111 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"quant/internal/domain/entity"
+)
+
+// TestScenario4_RunJobWithContextFeedsGate covers the issue #50 gap that the
+// trigger-edge path did not: a job entered OUTSIDE a real trigger edge — via
+// run_job_with_context (orchestrator kickoff, retry, self-heal re-fire) — can
+// now satisfy `required` inputs by passing the structured `inputs` arg.
+//
+//   - The freeform `context` arg is PROMPT-ONLY (env QUANT_TRIGGER_CONTEXT for
+//     bash). It never reaches the validation gate, so context alone leaves a
+//     required job failing the gate before it executes.
+//   - The new `inputs` arg pre-seeds the root run's metadata (the "inbound" the
+//     gate validates), so the same job passes — and both can be supplied at
+//     once: the agent gets human-readable context AND the contract is met.
+func TestScenario4_RunJobWithContextFeedsGate(t *testing.T) {
+	h := newHarness(t)
+
+	// A job that declares a required input (linearId) and passes it through,
+	// plus a produced output. Its script records the injected context to a
+	// marker file so we can prove (a) context injection still works and
+	// (b) the gate blocked execution when it should have (no marker).
+	makeJob := func(name, marker string) string {
+		script := `echo "ctx=$QUANT_TRIGGER_CONTEXT" > "` + marker + `"
+echo '<quant-output>{"prUrl":"https://github.com/x/y/pull/7"}</quant-output>'`
+		return h.createBash(t, name, script,
+			[]entity.JobInputSpec{in("linearId", "string", true)},
+			[]entity.JobOutputSpec{outP("prUrl", "string"), outT("linearId", "string")})
+	}
+
+	t.Run("context_only_fails_gate", func(t *testing.T) {
+		marker := filepath.Join(t.TempDir(), "ctx-only-marker")
+		jID := makeJob("s4a-job", marker)
+
+		// Prompt context but NO structured inputs: the gate must fail before
+		// the script runs (this is the pre-fix behavior the orchestrator hit).
+		run := h.call("run_job_with_context", map[string]any{
+			"id":      jID,
+			"context": "TASK_IDENTIFIER=MAX-99\nNOTE=kickoff",
+		})
+		runID, _ := run["id"].(string)
+		final := h.pollRunTerminal(runID, pollTimeout)
+
+		if final["status"] != "failed" {
+			t.Errorf("expected failed (gate), got %v", final["status"])
+		}
+		ve, _ := final["validationError"].(string)
+		if !strings.Contains(ve, "linearId") {
+			t.Errorf("validationError should mention linearId, got %q", ve)
+		}
+		// Gate blocked execution before the script ran -> no marker written.
+		if _, err := os.Stat(marker); err == nil {
+			t.Errorf("marker exists but the gate should have blocked execution")
+		}
+	})
+
+	t.Run("inputs_feed_gate_and_context_still_injected", func(t *testing.T) {
+		marker := filepath.Join(t.TempDir(), "both-marker")
+		jID := makeJob("s4b-job", marker)
+
+		ctxStr := "TASK_IDENTIFIER=MAX-99\nNOTE=kickoff"
+		run := h.call("run_job_with_context", map[string]any{
+			"id":      jID,
+			"context": ctxStr,
+			"inputs":  jsonStr(t, map[string]any{"linearId": "MAX-99"}),
+		})
+		runID, _ := run["id"].(string)
+		final := h.pollRunTerminal(runID, pollTimeout)
+
+		if final["status"] != "success" {
+			t.Fatalf("expected success, got %v (validationError=%v)", final["status"], final["validationError"])
+		}
+		meta, _ := final["metadata"].(map[string]any)
+		// Produced output proves the script ran (gate passed).
+		if meta["prUrl"] != "https://github.com/x/y/pull/7" {
+			t.Errorf("expected produced prUrl, got %v", meta["prUrl"])
+		}
+		// linearId passthrough proves the `inputs` arg became inbound metadata
+		// the gate validated and carried forward — not just prompt text.
+		if meta["linearId"] != "MAX-99" {
+			t.Errorf("expected linearId passthrough from inputs, got %v", meta["linearId"])
+		}
+		// And the freeform context was still injected (bash env path).
+		data, err := os.ReadFile(marker)
+		if err != nil {
+			t.Fatalf("read context marker: %v", err)
+		}
+		if !strings.Contains(string(data), "TASK_IDENTIFIER=MAX-99") {
+			t.Errorf("injected context missing from QUANT_TRIGGER_CONTEXT; got %q", string(data))
+		}
+	})
+
+	t.Run("invalid_inputs_json_is_rejected", func(t *testing.T) {
+		jID := makeJob("s4c-job", filepath.Join(t.TempDir(), "noop-marker"))
+		errText := h.callExpectError("run_job_with_context", map[string]any{
+			"id":      jID,
+			"context": "x",
+			"inputs":  "{not valid json",
+		})
+		if !strings.Contains(errText, "invalid inputs JSON") {
+			t.Errorf("expected 'invalid inputs JSON' error, got %q", errText)
+		}
+	})
+}

--- a/internal/integration/mcp/server.go
+++ b/internal/integration/mcp/server.go
@@ -294,9 +294,12 @@ Use this to start a pipeline at any step without depending on a previous run exi
 Useful for:
 - Retrying a specific stage after fixing a job prompt
 - Starting mid-pipeline for testing a new job
-- Recovering a broken pipeline without re-running expensive upstream jobs`),
+- Recovering a broken pipeline without re-running expensive upstream jobs
+
+The 'context' string is PROMPT-ONLY — it is not parsed into structured metadata and does NOT satisfy a job's pre-run validation gate. When the target job declares required inputs and you are entering it OUTSIDE a trigger edge (orchestrator kickoff, retry, self-heal re-fire), ALSO pass 'inputs' (a JSON object): for a root run these become the run's initial metadata and feed the gate, exactly like run_job. Pass both to give the agent human-readable context AND satisfy the contract.`),
 			mcp.WithString("id", mcp.Required(), mcp.Description("Job ID to run (get from list_jobs)")),
-			mcp.WithString("context", mcp.Required(), mcp.Description("Freeform string injected as trigger context into the job's prompt")),
+			mcp.WithString("context", mcp.Required(), mcp.Description("Freeform string injected as trigger context into the job's prompt (prompt-only; does not feed the validation gate)")),
+			mcp.WithString("inputs", mcp.Description(`Optional JSON object of typed inputs that feed the pre-run validation gate. Example: {"linearId":"MAX-86","stack":"backend"}. Use when the target job declares required inputs. Default: none.`)),
 		),
 		s.handleRunJobWithContext,
 	)
@@ -1215,7 +1218,21 @@ func (s *QuantMCPServer) handleRunJobWithContext(_ context.Context, request mcp.
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	run, err := s.jobManager.RunJobWithContext(id, ctx)
+	// issue #50: optional typed inputs (JSON object string) that feed the
+	// pre-run validation gate. The 'context' arg above is prompt-only and does
+	// NOT satisfy required inputs; pass 'inputs' to kickoff/retry/self-heal a
+	// job that declares them. Mirrors handleRunJob's parsing.
+	var inputs map[string]any
+	if v, ok := request.GetArguments()["inputs"]; ok {
+		raw, _ := v.(string)
+		if strings.TrimSpace(raw) != "" {
+			if err := json.Unmarshal([]byte(raw), &inputs); err != nil {
+				return mcp.NewToolResultError("invalid inputs JSON: " + err.Error()), nil
+			}
+		}
+	}
+
+	run, err := s.jobManager.RunJobWithContext(id, ctx, inputs)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}


### PR DESCRIPTION
## Problem

`run_job_with_context` injected its `context` argument into the job's **prompt only**. The issue-50 pre-run validation gate validates the **root run's metadata**, which prompt injection never populates. So a job that declares `required` inputs and is entered **outside a real trigger edge** — orchestrator kickoff, retry re-fire, self-heal re-fire — could **never** satisfy the gate: it failed before executing, every time.

This is why those entry-point jobs (`plan`, `orchestrator`, `build`, `review-fix`) had to leave their inputs optional. The gate worked only on jobs reached by an `onSuccess`/`onFailure` edge (which carries the upstream run's typed metadata).

## Fix

Add an optional `inputs` (JSON object) argument to `run_job_with_context`, mirroring the one `run_job` already has. For a root run it pre-seeds `run.Metadata`, so the gate validates against it — exactly the path a trigger edge uses.

- `context` stays **prompt-only** (unchanged).
- `inputs` is what **feeds the gate**.
- Pass **both** to give the agent human-readable context *and* satisfy the contract.
- **Backward compatible**: omitting `inputs` reproduces the previous behavior.

Touch points: MCP tool def + handler (`internal/integration/mcp/server.go`), the `JobManager` interface, and `RunJobWithContext` (threads `inputs` into the existing `RunJob(jobID, "", inputs)` root-run path).

## Testing

`go vet` + `go build` clean. New e2e coverage in `internal/e2e/context_inputs_test.go` (`TestScenario4`), plus the full existing e2e + service suites pass:

- **context-only** → fails the gate *before* execution (`validationError` names the missing key; script never runs)
- **context + inputs** → succeeds, `inputs` becomes gate-validated inbound metadata (verified via passthrough), and `context` is still injected (`QUANT_TRIGGER_CONTEXT`)
- **malformed `inputs` JSON** → rejected with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)