### PR TITLE
fix: display the real release version by injecting the build tag (ldflags)

### DIFF
--- a/internal/integration/entrypoint/controller/changelog.go
+++ b/internal/integration/entrypoint/controller/changelog.go
@@ -9,6 +9,16 @@ import (
 	"quant/internal/domain/entity"
 )
 
+// Version is the app version, injected at build time via
+//
+//	-ldflags "-X quant/internal/integration/entrypoint/controller.Version=v3.1.23"
+//
+// (the Homebrew formula sets it to the release tag). It is empty for `go run`
+// and source builds without that flag, in which case GetVersion falls back to
+// the newest changelog entry. Injecting the tag keeps the displayed version in
+// lockstep with the actual release, instead of trailing changelog.json.
+var Version string
+
 // changelogController implements the integration adapter.ChangelogController interface.
 type changelogController struct {
 	ctx           context.Context
@@ -39,8 +49,13 @@ func (c *changelogController) GetChangelog() (*entity.Changelog, error) {
 	return &changelog, nil
 }
 
-// GetVersion returns the current app version (latest tag from changelog).
+// GetVersion returns the current app version. It prefers the build-time
+// injected Version (the release tag); when that is empty (dev/source builds)
+// it falls back to the newest changelog entry.
 func (c *changelogController) GetVersion() string {
+	if Version != "" {
+		return Version
+	}
 	var changelog entity.Changelog
 	if err := json.Unmarshal(c.changelogData, &changelog); err != nil || len(changelog.Entries) == 0 {
 		return "v0.0.0"

--- a/internal/integration/entrypoint/controller/changelog_test.go
+++ b/internal/integration/entrypoint/controller/changelog_test.go
@@ -1,0 +1,37 @@
+package controller
+
+import "testing"
+
+// TestGetVersion verifies the version source: the build-time injected Version
+// (set via -ldflags "-X ...Version=...") takes precedence, and source builds
+// without it fall back to the newest changelog entry.
+//
+// Run without ldflags -> exercises the fallback branch.
+// Run with    go test -ldflags "-X quant/internal/integration/entrypoint/controller.Version=v9.9.9"
+//   -> exercises the injected branch and proves the ldflags symbol path is exact.
+func TestGetVersion(t *testing.T) {
+	c := NewChangelogController([]byte(`{"entries":[{"version":"v1.2.3"},{"version":"v1.2.2"}]}`))
+	got := c.GetVersion()
+
+	if Version != "" {
+		if got != Version {
+			t.Fatalf("with injected build version: want %q, got %q", Version, got)
+		}
+		return
+	}
+	if got != "v1.2.3" {
+		t.Fatalf("source build (no ldflags): want changelog fallback %q, got %q", "v1.2.3", got)
+	}
+}
+
+// TestGetVersion_EmptyChangelogFallback ensures a missing/empty changelog with
+// no injected version degrades to a sentinel rather than panicking.
+func TestGetVersion_EmptyChangelogFallback(t *testing.T) {
+	if Version != "" {
+		t.Skip("build version injected; fallback path not exercised")
+	}
+	c := NewChangelogController([]byte(`{"entries":[]}`))
+	if got := c.GetVersion(); got != "v0.0.0" {
+		t.Fatalf("want v0.0.0 sentinel, got %q", got)
+	}
+}


### PR DESCRIPTION
## Problem
The app's displayed version comes from `changelog.json`'s newest entry (`ChangelogController.GetVersion`), but neither release workflow updates `changelog.json`. So the label trails the actual build — a freshly-released **3.1.23** binary still shows **v3.1.22** (same lag PR #57 patched up by hand).

## Fix
Inject the release tag into the binary at build time and prefer it:
- New package var `Version` in `internal/integration/entrypoint/controller`, set via `-ldflags "-X quant/internal/integration/entrypoint/controller.Version=v<tag>"`.
- `GetVersion()` returns it when set, else falls back to the newest changelog entry (so `go run` / source builds and any build *without* the flag are unaffected — safe no-op).

## Pairs with a formula change (separate repo)
The actual `wails build` runs in **`brienze1/homebrew-tap`**'s `quant.rb`. Its build step must pass the ldflag:
```ruby
system wails, "build", "-ldflags", "-X quant/internal/integration/entrypoint/controller.Version=v#{version}"
```
Until that lands, this PR is a harmless no-op (falls back to changelog). **Merge the formula change first**, then merge this — the resulting release will display its true version.

## Testing
`go build` clean. New `changelog_test.go` covers both branches:
- no ldflags → changelog fallback
- `go test -ldflags "-X …Version=v9.9.9"` → returns `v9.9.9` (proves the exact symbol path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)