### PR TITLE
feat(mindmap): cross-session board edits over MCP

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,15 @@
 {
   "entries": [
     {
+      "version": "v3.1.27",
+      "date": "2026-06-02",
+      "changes": {
+        "features": [
+          "agents can now edit another session's mindmap over MCP: mindmap_set_node, mindmap_remove_node and mindmap_clear take an optional sessionId, so an orchestrator agent can draw on or tidy a worker session's board (omit it to keep editing your own)"
+        ]
+      }
+    },
+    {
       "version": "v3.1.26",
       "date": "2026-06-02",
       "changes": {

--- a/internal/integration/mcp/server.go
+++ b/internal/integration/mcp/server.go
@@ -930,6 +930,7 @@ Example flow: run_job("health-check") → get_pipeline_status(runId) shows:
 			mcp.WithString("kind", mcp.Description("Node kind: node | note. Defaults to node. Use note for a free-floating sticky."), mcp.Enum("node", "note")),
 			mcp.WithString("text", mcp.Description("Sticky body text (for kind=note).")),
 			mcp.WithString("board", mcp.Description("Named board to draw on. Use a board per topic/workstream to keep separate maps. Omit for the default board.")),
+			mcp.WithString("sessionId", mcp.Description("Draw on ANOTHER session's mindmap by its session id. Omit to draw on THIS session's mindmap. Use mindmap_list_boards to discover sessions.")),
 		),
 		s.handleMindmapSetNode,
 	)
@@ -941,6 +942,7 @@ Example flow: run_job("health-check") → get_pipeline_status(runId) shows:
 			mcp.WithString("id", mcp.Required(), mcp.Description("Id of the node to remove.")),
 			mcp.WithBoolean("subtree", mcp.Description("If true, also remove all descendant nodes. Defaults to false.")),
 			mcp.WithString("board", mcp.Description("Named board to remove from. Omit for the default board.")),
+			mcp.WithString("sessionId", mcp.Description("Remove from ANOTHER session's mindmap by its session id. Omit to target THIS session's mindmap.")),
 		),
 		s.handleMindmapRemoveNode,
 	)
@@ -950,6 +952,7 @@ Example flow: run_job("health-check") → get_pipeline_status(runId) shows:
 		mcp.NewTool("mindmap_clear",
 			mcp.WithDescription(`Clear the entire live mindmap for THIS session, removing all nodes. Use when starting a fresh plan. Use the optional 'board' to clear a specific board; omit for the default board.`),
 			mcp.WithString("board", mcp.Description("Named board to clear. Omit for the default board.")),
+			mcp.WithString("sessionId", mcp.Description("Clear ANOTHER session's mindmap board by its session id. Omit to target THIS session's mindmap.")),
 		),
 		s.handleMindmapClear,
 	)
@@ -1655,6 +1658,16 @@ func (s *QuantMCPServer) scopeFromCtx(ctx context.Context) (scopeType, scopeID s
 	return "workspace", "default"
 }
 
+// scopeForArgs resolves the mindmap scope for a request. An explicit "sessionId"
+// argument targets another session (cross-session read or write); otherwise it
+// falls back to the caller's own scope from the request context.
+func (s *QuantMCPServer) scopeForArgs(ctx context.Context, args map[string]any) (scopeType, scopeID string) {
+	if sid := stringArg(args, "sessionId"); sid != "" {
+		return "session", sid
+	}
+	return s.scopeFromCtx(ctx)
+}
+
 // mindmapNodeToMap maps a MindmapNode to the camelCase frontend JSON shape.
 func mindmapNodeToMap(n *entity.MindmapNode) map[string]any {
 	return map[string]any{
@@ -1687,7 +1700,7 @@ func (s *QuantMCPServer) handleMindmapSetNode(ctx context.Context, request mcp.C
 	}
 
 	args := request.GetArguments()
-	scopeType, scopeID := s.scopeFromCtx(ctx)
+	scopeType, scopeID := s.scopeForArgs(ctx, args)
 	board := mindmapBoardArg(args)
 
 	// Default progress to -1 (no progress bar) unless the caller provided one.
@@ -1723,7 +1736,7 @@ func (s *QuantMCPServer) handleMindmapRemoveNode(ctx context.Context, request mc
 	}
 
 	args := request.GetArguments()
-	scopeType, scopeID := s.scopeFromCtx(ctx)
+	scopeType, scopeID := s.scopeForArgs(ctx, args)
 	board := mindmapBoardArg(args)
 	subtree := boolArg(args, "subtree")
 
@@ -1735,8 +1748,9 @@ func (s *QuantMCPServer) handleMindmapRemoveNode(ctx context.Context, request mc
 }
 
 func (s *QuantMCPServer) handleMindmapClear(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	scopeType, scopeID := s.scopeFromCtx(ctx)
-	board := mindmapBoardArg(request.GetArguments())
+	args := request.GetArguments()
+	scopeType, scopeID := s.scopeForArgs(ctx, args)
+	board := mindmapBoardArg(args)
 
 	if err := s.mindmapManager.ClearMindmap(scopeType, scopeID, board); err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -1747,11 +1761,7 @@ func (s *QuantMCPServer) handleMindmapClear(ctx context.Context, request mcp.Cal
 
 func (s *QuantMCPServer) handleMindmapGet(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
-	scopeType, scopeID := s.scopeFromCtx(ctx)
-	// An explicit sessionId reads another session's board (read-only).
-	if sid := stringArg(args, "sessionId"); sid != "" {
-		scopeType, scopeID = "session", sid
-	}
+	scopeType, scopeID := s.scopeForArgs(ctx, args)
 	board := mindmapBoardArg(args)
 
 	nodes, _ := s.mindmapManager.GetMindmap(scopeType, scopeID, board)


### PR DESCRIPTION
Follow-up to the cross-session **read** support (#63): allow an agent to **edit** another session's mindmap board over MCP.

## What changed
- `mindmap_set_node`, `mindmap_remove_node`, and `mindmap_clear` each gain an optional `sessionId`. When provided, the operation targets that session's board (e.g. an orchestrator agent curating a worker session's map). Omitting it preserves the prior **this-session-only** behavior.
- A shared `scopeForArgs(ctx, args)` helper resolves the `sessionId` override (falling back to the caller's own scope); `mindmap_get` was refactored onto it too, so all four mindmap tools now share one scope-resolution path.

## Notes / trade-offs
- This is intentionally permissive: any session can now write to any other session's board. The trust boundary remains the same as before — the `X-Quant-Session` header / `sessionId` simply names the target scope; there is no per-session ACL.
- Writes still broadcast `mindmap:updated`, so the target session's pane (and any remote client) updates live.
- `go build ./...` passes.

Changelog: v3.1.27.