### PR TITLE
fix(macos): enable microphone for voice tools in the integrated terminal

### DIFF
--- a/build/darwin/Info.dev.plist
+++ b/build/darwin/Info.dev.plist
@@ -64,5 +64,7 @@
             <key>NSAllowsLocalNetworking</key>
             <true/>
         </dict>
+        <key>NSMicrophoneUsageDescription</key>
+        <string>Quant needs microphone access to use voice features in the integrated terminal.</string>
     </dict>
 </plist>

--- a/build/darwin/Info.plist
+++ b/build/darwin/Info.plist
@@ -59,5 +59,7 @@
           {{end}}
         </array>
         {{end}}
+        <key>NSMicrophoneUsageDescription</key>
+        <string>Quant needs microphone access to use voice features in the integrated terminal.</string>
     </dict>
 </plist>

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,15 @@
 {
   "entries": [
     {
+      "version": "v3.1.28",
+      "date": "2026-06-06",
+      "changes": {
+        "fixes": [
+          "voice tools now work in the integrated terminal on macOS — the app declares microphone access so the system prompts for permission (previously you could hear audio play back but speech was never captured)"
+        ]
+      }
+    },
+    {
       "version": "v3.1.27",
       "date": "2026-06-02",
       "changes": {


### PR DESCRIPTION
## Problem

Voice tools run inside Quant's integrated terminal could **play audio back but never captured the microphone** — you could hear TTS but speech was never transcribed. The same tools work when run from iTerm/Terminal.

## Root cause

Quant (Wails v2) spawns the terminal's shell and its descendants as **child processes of `quant.app`** (via `creack/pty` in `internal/integration/process/manager.go`). macOS TCC attributes a microphone request to the **responsible app at the top of the process tree** — i.e. `quant.app` (bundle id `com.wails.quant`). The app's `Info.plist` had **no `NSMicrophoneUsageDescription`**, so macOS never prompted and silently denied mic capture to the app and every child it spawns. Audio output needs no TCC permission, which is why playback worked but input didn't. In iTerm/Terminal the responsible app is that terminal, which already has a mic grant — hence it worked there.

## Fix

Declare `NSMicrophoneUsageDescription` in both Wails plist templates:
- `build/darwin/Info.plist` (production `wails build`)
- `build/darwin/Info.dev.plist` (`wails dev`)

The app is ad-hoc signed with no hardened runtime or App Sandbox, so the usage-description key alone is sufficient — no entitlements file needed.

## Verification

- `wails dev` from this branch builds an app bundle whose `Contents/Info.plist` now contains the key (verified with PlistBuddy).
- Launched that build, ran a voice session in the integrated terminal: macOS prompted for microphone access for Quant, and after approving, speech was captured/transcribed. Confirmed working.

## Changelog

Added `v3.1.28` `fixes` entry to `changelog.json` (auto-release will tag v3.1.28 on merge).