### PR TITLE
feat(sessions): auto-submit messages sent to a session over MCP

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,15 @@
 {
   "entries": [
     {
+      "version": "v3.1.29",
+      "date": "2026-06-06",
+      "changes": {
+        "features": [
+          "messages sent to another session over MCP (send_message) now submit on their own — an orchestrator agent can prompt a worker session and it runs immediately instead of waiting for you to press Enter; pass submit=false to only type the text"
+        ]
+      }
+    },
+    {
       "version": "v3.1.28",
       "date": "2026-06-06",
       "changes": {

--- a/internal/e2e/harness_test.go
+++ b/internal/e2e/harness_test.go
@@ -67,6 +67,7 @@ func newHarness(t *testing.T) *harness {
 		injector.WorkspaceManager(),
 		injector.RepoManager(),
 		injector.JobGroupManager(),
+		injector.MindmapManager(),
 	)
 	if err := server.Start(); err != nil {
 		t.Fatalf("server.Start: %v", err)

--- a/internal/e2e/session_submit_test.go
+++ b/internal/e2e/session_submit_test.go
@@ -1,0 +1,97 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSendMessageAutoSubmit verifies that send_message, by default, not only
+// types text into a session's PTY but also delivers an Enter keystroke so the
+// command actually runs. The negative case (submit=false) proves the text is
+// typed but NOT executed.
+//
+// The test drives a real "terminal" session (a login shell in a PTY) and uses
+// a command whose OUTPUT differs from its INPUT — `echo R$((6*7))Z` — so that
+// finding "R42Z" in the session output can only mean the command was submitted
+// and executed, not merely echoed back as typed characters.
+func TestSendMessageAutoSubmit(t *testing.T) {
+	// Use bash for a deterministic interactive shell regardless of the
+	// developer's personal zsh profile.
+	t.Setenv("SHELL", "/bin/bash")
+
+	h := newHarness(t)
+
+	startTerminal := func(name string) string {
+		created := h.call("create_session", map[string]any{
+			"name":        name,
+			"sessionType": "terminal",
+		})
+		id, _ := created["id"].(string)
+		if id == "" {
+			t.Fatalf("create_session returned no id: %v", created)
+		}
+		h.callRaw("start_session", map[string]any{"id": id}, false)
+		// Give the login shell time to come up and print its first prompt.
+		time.Sleep(700 * time.Millisecond)
+		return id
+	}
+
+	waitForOutput := func(id, want string, timeout time.Duration) (string, bool) {
+		deadline := time.Now().Add(timeout)
+		var last string
+		for time.Now().Before(deadline) {
+			last = h.callRaw("get_session_output", map[string]any{"id": id, "lines": float64(0)}, false)
+			if strings.Contains(last, want) {
+				return last, true
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		return last, false
+	}
+
+	t.Run("submit true runs the command", func(t *testing.T) {
+		id := startTerminal("orch-submit-true")
+		h.callRaw("send_message", map[string]any{
+			"id":      id,
+			"message": "echo R$((6*7))Z",
+			"submit":  true,
+		}, false)
+		out, ok := waitForOutput(id, "R42Z", 4*time.Second)
+		if !ok {
+			t.Fatalf("expected command to run and produce R42Z, but it did not.\noutput:\n%s", out)
+		}
+	})
+
+	t.Run("submit defaults to true when omitted", func(t *testing.T) {
+		id := startTerminal("orch-submit-default")
+		h.callRaw("send_message", map[string]any{
+			"id":      id,
+			"message": "echo D$((6*7))Z",
+		}, false)
+		out, ok := waitForOutput(id, "D42Z", 4*time.Second)
+		if !ok {
+			t.Fatalf("expected default submit to run the command (D42Z), but it did not.\noutput:\n%s", out)
+		}
+	})
+
+	t.Run("submit false types but does not run", func(t *testing.T) {
+		id := startTerminal("orch-submit-false")
+		h.callRaw("send_message", map[string]any{
+			"id":      id,
+			"message": "echo N$((6*7))Z",
+			"submit":  false,
+		}, false)
+		// Give it the same window the positive case needed; the computed result
+		// must still be absent because Enter was never sent.
+		if out, ran := waitForOutput(id, "N42Z", 1500*time.Millisecond); ran {
+			t.Fatalf("submit=false should not execute the command, but N42Z appeared.\noutput:\n%s", out)
+		}
+		// Now press Enter via a follow-up submit and confirm it runs, proving
+		// the text really was sitting in the input buffer all along.
+		h.callRaw("send_message", map[string]any{"id": id, "message": "", "submit": true}, false)
+		if out, ran := waitForOutput(id, "N42Z", 4*time.Second); !ran {
+			t.Fatalf("after a follow-up Enter the buffered command should run (N42Z).\noutput:\n%s", out)
+		}
+	})
+}

--- a/internal/integration/mcp/server.go
+++ b/internal/integration/mcp/server.go
@@ -706,9 +706,10 @@ Returns the created session object with generated ID. The session starts in 'idl
 
 	mcpServer.AddTool(
 		mcp.NewTool("send_message",
-			mcp.WithDescription(`Send a message to a running session. The message is written to the session's terminal stdin. For claude sessions, this sends text to the Claude CLI.`),
+			mcp.WithDescription(`Send a message to a running session. The message is written to the session's terminal stdin. For claude sessions, this sends text to the Claude CLI and, by default, presses Enter to submit it (delivered as a separate keystroke so the TUI treats it as a submit, not a multi-line paste). Set submit=false to leave the text in the input box without submitting.`),
 			mcp.WithString("id", mcp.Required(), mcp.Description("Session ID (must be running)")),
 			mcp.WithString("message", mcp.Required(), mcp.Description("Message text to send to the session")),
+			mcp.WithBoolean("submit", mcp.Description("Press Enter after the message to submit it. Default: true. Set false to only type the text without submitting.")),
 		),
 		s.handleSendMessage,
 	)
@@ -2205,12 +2206,38 @@ func (s *QuantMCPServer) handleSendMessage(_ context.Context, request mcp.CallTo
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	// submit defaults to true: the orchestration use case is to deliver a
+	// prompt to another session, which is useless if it just sits in the input
+	// box. Callers can opt out to only type the text.
+	submit := true
+	if v, ok := request.GetArguments()["submit"]; ok && v != nil {
+		submit, _ = v.(bool)
+	}
+
 	if err := s.sessionManager.SendMessage(id, message); err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	return mcp.NewToolResultText(fmt.Sprintf("Message sent to session %s", id)), nil
+	if submit {
+		// The Claude CLI TUI treats a carriage return arriving in the same
+		// write as the message text as a multi-line newline, not a submit.
+		// Delivering Enter as a separate keystroke after a short delay lets the
+		// TUI process the pasted text first, so the return is read as a submit.
+		time.Sleep(submitKeyDelay)
+		if err := s.sessionManager.SendMessage(id, "\r"); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("message typed but submit (Enter) failed: %s", err.Error())), nil
+		}
+		return mcp.NewToolResultText(fmt.Sprintf("Message sent and submitted to session %s", id)), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("Message typed (not submitted) to session %s", id)), nil
 }
+
+// submitKeyDelay is the pause between writing a message to a session's PTY and
+// writing the Enter keystroke that submits it. It gives the Claude CLI TUI time
+// to process the pasted text before the carriage return arrives as a discrete
+// submit rather than a multi-line newline.
+const submitKeyDelay = 120 * time.Millisecond
 
 func (s *QuantMCPServer) handleGetSessionOutput(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	id, err := requiredString(request, "id")


### PR DESCRIPTION
## What

`send_message` (the MCP tool that writes to another session's terminal stdin) now **submits** the message by default instead of leaving it sitting in the input box.

This unblocks cross-session orchestration: an orchestrator session can prompt a worker session and it runs immediately, with no human pressing Enter.

## Why it was broken

The handler wrote the message text to the PTY but never sent Enter. Worse, appending a carriage return to the same write doesn't help — the Claude CLI TUI reads a newline arriving in the same chunk as the text as a multi-line newline, not a submit (the same gotcha tmux-orchestration setups hit with `send-keys`).

## The fix

- After writing the message, wait ~120ms, then write `\r` as a **separate** keystroke so the TUI registers it as a submit.
- Auto-submit is the default. New optional `submit=false` types the text without submitting.
- Updated the tool description accordingly.

## Verification

New e2e test (`TestSendMessageAutoSubmit`) boots the full stack through the real MCP-over-HTTP server and drives a live PTY shell:
- `submit=true` / omitted → command actually executes
- `submit=false` → text typed but not executed; a follow-up Enter then runs it

Also fixes the e2e harness, which hadn't been updated for the `MindmapManager` constructor param (it didn't compile on main).

```
--- PASS: TestSendMessageAutoSubmit (4.06s)
    --- PASS: submit_true_runs_the_command
    --- PASS: submit_defaults_to_true_when_omitted
    --- PASS: submit_false_types_but_does_not_run
```

Changelog: v3.1.29.