### PR TITLE
feat(persona): make the agent base persona editable in Settings

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,15 @@
 {
   "entries": [
     {
+      "version": "v3.1.31",
+      "date": "2026-06-08",
+      "changes": {
+        "features": [
+          "the agent persona is now editable in Settings → Claude → 'agent persona': customize the base system prompt every session gets (how it should behave, what to emphasize, how it uses the mindmap and Quant tools), with 'load default to edit' and 'reset to default' buttons; leave it empty to keep the built-in default, which still updates with new releases"
+        ]
+      }
+    },
+    {
       "version": "v3.1.30",
       "date": "2026-06-08",
       "changes": {

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -773,6 +773,53 @@ function ClaudeTab({ config, update }: TabProps) {
         />
       </Section>
 
+      <Section
+        title="agent persona"
+        description="the base system prompt appended to every session quant spawns — it tells the agent it is quant, what quant is, and how to use the live mindmap + quant tools. Layered on top of each project's own context. Leave empty to use the built-in default."
+      >
+        <textarea
+          value={config.basePersona ?? ""}
+          onChange={(e) => update("basePersona", e.target.value)}
+          placeholder={config.defaultBasePersona || "Leave empty to use the built-in Quant persona…"}
+          spellCheck={false}
+          style={{
+            width: "100%",
+            minHeight: 160,
+            resize: "vertical",
+            boxSizing: "border-box",
+            backgroundColor: "var(--q-bg-input)",
+            border: "1px solid var(--q-border)",
+            color: "var(--q-fg)",
+            fontFamily: font,
+            fontSize: 12,
+            lineHeight: 1.5,
+            padding: 8,
+            outline: "none",
+          }}
+          onFocus={(e) => (e.currentTarget.style.borderColor = "var(--q-accent)")}
+          onBlur={(e) => (e.currentTarget.style.borderColor = "var(--q-border)")}
+        />
+        <div className="flex items-center gap-3 mt-2">
+          <button
+            onClick={() => update("basePersona", config.defaultBasePersona ?? "")}
+            disabled={!config.defaultBasePersona}
+            style={{ color: "var(--q-accent)", fontSize: 11, fontFamily: font, opacity: config.defaultBasePersona ? 1 : 0.4 }}
+          >
+            load default to edit
+          </button>
+          <button
+            onClick={() => update("basePersona", "")}
+            disabled={!(config.basePersona ?? "").trim()}
+            style={{ color: "var(--q-fg-muted)", fontSize: 11, fontFamily: font, opacity: (config.basePersona ?? "").trim() ? 1 : 0.4 }}
+          >
+            reset to default
+          </button>
+          <span style={{ color: "var(--q-fg-muted)", fontSize: 10, fontFamily: font }}>
+            {(config.basePersona ?? "").trim() ? "using your custom persona" : "using built-in default"}
+          </span>
+        </div>
+      </Section>
+
       <Section title="per-path command overrides" description="use a different claude command for sessions whose path contains the given substring">
         <div style={{ border: "1px solid var(--q-border)" }}>
           {/* Table Header */}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -272,6 +272,11 @@ export interface Config {
   assistantModel: string;
   envVariables: Record<string, string>;
   commandOverrides: Record<string, string>;
+  // Base persona appended to every spawned session. Empty = use the built-in
+  // default. `defaultBasePersona` is read-only (the built-in text) so the UI can
+  // show it as a placeholder and offer a reset-to-default action.
+  basePersona: string;
+  defaultBasePersona?: string;
 
   // Remote Access
   remoteAccessEnabled: boolean;

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -145,15 +145,17 @@ export namespace dto {
 	    assistantModel: string;
 	    envVariables: Record<string, string>;
 	    commandOverrides: Record<string, string>;
+	    basePersona: string;
+	    defaultBasePersona: string;
 	    remoteAccessEnabled: boolean;
 	    remoteAccessPort: number;
 	    remoteAccessPasscode: string;
 	    voice: VoiceConfigDTO;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new ConfigResponse(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.startOnLogin = source["startOnLogin"];
@@ -192,6 +194,8 @@ export namespace dto {
 	        this.assistantModel = source["assistantModel"];
 	        this.envVariables = source["envVariables"];
 	        this.commandOverrides = source["commandOverrides"];
+	        this.basePersona = source["basePersona"];
+	        this.defaultBasePersona = source["defaultBasePersona"];
 	        this.remoteAccessEnabled = source["remoteAccessEnabled"];
 	        this.remoteAccessPort = source["remoteAccessPort"];
 	        this.remoteAccessPasscode = source["remoteAccessPasscode"];
@@ -763,11 +767,12 @@ export namespace dto {
 	    assistantModel: string;
 	    envVariables: Record<string, string>;
 	    commandOverrides: Record<string, string>;
+	    basePersona: string;
 	    remoteAccessEnabled: boolean;
 	    remoteAccessPort: number;
 	    remoteAccessPasscode: string;
 	    voice: VoiceConfigDTO;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new SaveConfigRequest(source);
 	    }
@@ -810,6 +815,7 @@ export namespace dto {
 	        this.assistantModel = source["assistantModel"];
 	        this.envVariables = source["envVariables"];
 	        this.commandOverrides = source["commandOverrides"];
+	        this.basePersona = source["basePersona"];
 	        this.remoteAccessEnabled = source["remoteAccessEnabled"];
 	        this.remoteAccessPort = source["remoteAccessPort"];
 	        this.remoteAccessPasscode = source["remoteAccessPasscode"];

--- a/internal/application/service/config_manager.go
+++ b/internal/application/service/config_manager.go
@@ -20,6 +20,7 @@ type configManagerService struct {
 	sendNotification      usecase.SendNotification
 	setNewLineKey         usecase.SetNewLineKey
 	updateCliBinaryConfig usecase.UpdateCliBinaryConfig
+	updateBasePersona     usecase.UpdateBasePersona
 }
 
 // NewConfigManagerService creates a new ConfigManager service.
@@ -34,6 +35,7 @@ func NewConfigManagerService(
 	sendNotification usecase.SendNotification,
 	setNewLineKey usecase.SetNewLineKey,
 	updateCliBinaryConfig usecase.UpdateCliBinaryConfig,
+	updateBasePersona usecase.UpdateBasePersona,
 ) adapter.ConfigManager {
 	return &configManagerService{
 		loadConfig:            loadConfig,
@@ -45,6 +47,7 @@ func NewConfigManagerService(
 		sendNotification:      sendNotification,
 		setNewLineKey:         setNewLineKey,
 		updateCliBinaryConfig: updateCliBinaryConfig,
+		updateBasePersona:     updateBasePersona,
 	}
 }
 
@@ -74,6 +77,7 @@ func (s *configManagerService) SaveConfig(cfg *entity.Config) error {
 	}
 
 	s.updateCliBinaryConfig.UpdateCliBinaryConfig(cfg.CliBinaryPath, cfg.CommandOverrides)
+	s.updateBasePersona.UpdateBasePersona(cfg.BasePersona)
 
 	return nil
 }

--- a/internal/application/usecase/update_base_persona.go
+++ b/internal/application/usecase/update_base_persona.go
@@ -1,0 +1,8 @@
+package usecase
+
+// UpdateBasePersona defines the interface for pushing the configured base persona
+// (the system prompt appended to spawned sessions) to the process layer so it is
+// applied to the next session started, without a restart.
+type UpdateBasePersona interface {
+	UpdateBasePersona(basePersona string)
+}

--- a/internal/domain/entity/config.go
+++ b/internal/domain/entity/config.go
@@ -127,6 +127,13 @@ type Config struct {
 	EnvVariables     map[string]string `json:"envVariables"`
 	CommandOverrides map[string]string `json:"commandOverrides"`
 
+	// BasePersona is the system prompt Quant appends (via --append-system-prompt)
+	// to every interactive session it spawns, layered on top of the user's project
+	// context. Empty means "use the built-in default" (persona.Base) so improvements
+	// to the shipped default reach users who never customized it; a non-empty value
+	// fully replaces it. Honored only when QUANT_SKIP_PERSONA != "1".
+	BasePersona string `json:"basePersona"`
+
 	// Remote Access — expose the UI in a browser via a Cloudflare quick tunnel,
 	// guarded by a generated passcode. Off by default; see internal/integration/remote.
 	RemoteAccessEnabled  bool   `json:"remoteAccessEnabled"`
@@ -186,6 +193,8 @@ func NewDefaultConfig() Config {
 		AssistantModel:   "claude-sonnet-4-6",
 		EnvVariables:     make(map[string]string),
 		CommandOverrides: make(map[string]string),
+		// Empty = use the built-in persona.Base; the user can override it in Settings.
+		BasePersona: "",
 
 		// Remote Access — disabled until the user opts in. Port 0 = auto-pick a
 		// free port; passcode is generated on first enable.

--- a/internal/infra/dependency/injector.go
+++ b/internal/infra/dependency/injector.go
@@ -110,6 +110,7 @@ func (i *Injector) ProcessManager() intAdapter.ProcessManager {
 		// used from the very first session, not just after the user opens Settings.
 		if cfg, err := i.ConfigPersistence().LoadConfig(); err == nil && cfg != nil {
 			pm.UpdateCliBinaryConfig(cfg.CliBinaryPath, cfg.CommandOverrides)
+			pm.UpdateBasePersona(cfg.BasePersona)
 		}
 		i.processManager = pm
 	}
@@ -252,6 +253,7 @@ func (i *Injector) ConfigManager() appAdapter.ConfigManager {
 			notification.NewManager(), // SendNotification
 			keybindings.NewManager(),  // SetNewLineKey
 			i.ProcessManager(),        // UpdateCliBinaryConfig
+			i.ProcessManager(),        // UpdateBasePersona
 		)
 	}
 	return i.configManager

--- a/internal/integration/adapter/process_manager.go
+++ b/internal/integration/adapter/process_manager.go
@@ -11,5 +11,6 @@ import (
 type ProcessManager interface {
 	usecase.SpawnProcess
 	usecase.UpdateCliBinaryConfig
+	usecase.UpdateBasePersona
 	SetContext(ctx context.Context)
 }

--- a/internal/integration/entrypoint/dto/config.go
+++ b/internal/integration/entrypoint/dto/config.go
@@ -3,6 +3,7 @@ package dto
 
 import (
 	"quant/internal/domain/entity"
+	"quant/internal/domain/persona"
 )
 
 // ShortcutDTO represents a named shell command in config.
@@ -79,6 +80,7 @@ type SaveConfigRequest struct {
 	AssistantModel   string            `json:"assistantModel"`
 	EnvVariables     map[string]string `json:"envVariables"`
 	CommandOverrides map[string]string `json:"commandOverrides"`
+	BasePersona      string            `json:"basePersona"` // empty = use built-in default
 
 	// Remote Access
 	RemoteAccessEnabled  bool   `json:"remoteAccessEnabled"`
@@ -138,6 +140,10 @@ type ConfigResponse struct {
 	AssistantModel   string            `json:"assistantModel"`
 	EnvVariables     map[string]string `json:"envVariables"`
 	CommandOverrides map[string]string `json:"commandOverrides"`
+	BasePersona      string            `json:"basePersona"` // user override; empty = built-in default in use
+	// DefaultBasePersona is read-only: the built-in persona.Base text, so the UI can
+	// show it as the placeholder/preview and offer a "reset to default" action.
+	DefaultBasePersona string `json:"defaultBasePersona"`
 
 	// Remote Access
 	RemoteAccessEnabled  bool   `json:"remoteAccessEnabled"`
@@ -191,6 +197,8 @@ func ConfigResponseFromEntity(cfg entity.Config) ConfigResponse {
 		AssistantModel:        cfg.AssistantModel,
 		EnvVariables:          cfg.EnvVariables,
 		CommandOverrides:      cfg.CommandOverrides,
+		BasePersona:           cfg.BasePersona,
+		DefaultBasePersona:    persona.Base,
 		RemoteAccessEnabled:   cfg.RemoteAccessEnabled,
 		RemoteAccessPort:      cfg.RemoteAccessPort,
 		RemoteAccessPasscode:  cfg.RemoteAccessPasscode,
@@ -280,6 +288,7 @@ func (r SaveConfigRequest) ToEntity() entity.Config {
 		AssistantModel:        r.AssistantModel,
 		EnvVariables:          envVariables,
 		CommandOverrides:      commandOverrides,
+		BasePersona:           r.BasePersona,
 		RemoteAccessEnabled:   r.RemoteAccessEnabled,
 		RemoteAccessPort:      r.RemoteAccessPort,
 		RemoteAccessPasscode:  r.RemoteAccessPasscode,

--- a/internal/integration/process/manager.go
+++ b/internal/integration/process/manager.go
@@ -69,6 +69,7 @@ type processManager struct {
 	outputDir        string                    // base dir for output files (~/.quant/sessions/)
 	claudeBinaryPath string                    // command name or path for the default claude binary
 	commandOverrides map[string]string         // path substring -> resolved binary path
+	basePersona      string                    // user-configured base persona; empty = built-in persona.Base
 }
 
 // NewProcessManager creates a new process manager for Claude CLI processes.
@@ -144,6 +145,27 @@ func (m *processManager) UpdateCliBinaryConfig(cliBinaryPath string, commandOver
 	m.claudeBinaryPath = cliBinaryPath
 	m.commandOverrides = overrides
 	m.mu.Unlock()
+}
+
+// UpdateBasePersona stores the user-configured base persona used when spawning new
+// sessions. An empty string means "use the built-in persona.Base" (resolved at
+// spawn time), so clearing the field in Settings reverts to the shipped default.
+func (m *processManager) UpdateBasePersona(basePersona string) {
+	m.mu.Lock()
+	m.basePersona = basePersona
+	m.mu.Unlock()
+}
+
+// resolvePersona returns the persona text to inject: the user override when set,
+// otherwise the built-in default.
+func (m *processManager) resolvePersona() string {
+	m.mu.RLock()
+	custom := m.basePersona
+	m.mu.RUnlock()
+	if strings.TrimSpace(custom) != "" {
+		return custom
+	}
+	return persona.Base
 }
 
 // getClaudeBinary returns the binary to use for a session.
@@ -274,7 +296,7 @@ func (m *processManager) Spawn(sessionID string, sessionType string, directory s
 	// referenced by terminal sessions, which take the other branch). Passing it via
 	// env keeps newlines intact through the shellQuote+eval machinery.
 	if os.Getenv("QUANT_SKIP_PERSONA") != "1" {
-		baseEnv = append(baseEnv, "QUANT_BASE_PERSONA="+persona.Base)
+		baseEnv = append(baseEnv, "QUANT_BASE_PERSONA="+m.resolvePersona())
 	}
 	cmd.Env = baseEnv
 


### PR DESCRIPTION
## What

Makes the agent base persona — the system prompt Quant appends to every session it spawns — **editable in Settings → Claude → "agent persona"**, instead of being a hardcoded Go const.

## Why

The persona shipped in v3.1.30 as a fixed `persona.Base`. Users wanted to tailor how their agents behave (tone, what to emphasize, how they use the mindmap/Quant tools) without rebuilding.

## How

- New top-level `entity.Config.BasePersona` (empty = use the built-in `persona.Base`, so the shipped default keeps improving for anyone who never overrides it; a non-empty value replaces it).
- The built-in default is exposed **read-only** to the frontend as `defaultBasePersona`, so the Settings textarea can show it as the placeholder and offer **load default to edit** / **reset to default**.
- The value is pushed to the process layer via a new `UpdateBasePersona` setter (mirrors the existing `UpdateCliBinaryConfig` channel), applied on save **and** at startup, and resolved at spawn time. New sessions pick it up; existing sessions keep their cached prompt.
- `QUANT_SKIP_PERSONA=1` still disables the persona entirely.

## Validation

- `go build ./...` clean; `go test` green (`process`, `service` packages)
- `tsc --noEmit` clean
- Verified live in a `wails dev` instance (isolated `QUANT_HOME`): edit persists, "load default" populates the built-in text, fresh session picks up the change; real `~/.mcp.json` untouched.

Ships as **v3.1.31** via the auto-release pipeline on merge.