### PR TITLE
feat(voice): long-form recording mode (manual + agent-activated, live transcript)

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -7,7 +7,8 @@
         "features": [
           "voice recording mode — for long, thought-out answers that don't fit in one breath: while a session is listening, tap 'rec' (or just tell it 'I'm going to give a long answer, start recording') and the mic stays open across your pauses instead of cutting you off after a moment of silence; tap stop or say 'stop recording' when you're done and the whole thing is sent as one message",
           "see your words as you speak — the voice pane now shows a live transcript that fills in while you're recording, so you can watch what's being captured before you send it",
-          "agents can start recording for you: ask a session to record and it opens the mic in recording mode itself, then ends when you say 'stop recording' (or 'finish recording' / 'end recording') — handy for dictating a long instruction hands-free"
+          "agents can start recording for you: ask a session to record and it opens the mic in recording mode itself, then ends when you say 'stop recording' (or 'finish recording' / 'end recording') — handy for dictating a long instruction hands-free",
+          "the mindmap pane is now per-session — open it on the session you're working in without it popping open on every other tab and client; each session remembers its own open/closed state while you work, and everything starts closed on a fresh launch (board contents are unaffected and stay saved per session)"
         ]
       }
     },

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,17 @@
 {
   "entries": [
     {
+      "version": "v3.1.32",
+      "date": "2026-06-10",
+      "changes": {
+        "features": [
+          "voice recording mode — for long, thought-out answers that don't fit in one breath: while a session is listening, tap 'rec' (or just tell it 'I'm going to give a long answer, start recording') and the mic stays open across your pauses instead of cutting you off after a moment of silence; tap stop or say 'stop recording' when you're done and the whole thing is sent as one message",
+          "see your words as you speak — the voice pane now shows a live transcript that fills in while you're recording, so you can watch what's being captured before you send it",
+          "agents can start recording for you: ask a session to record and it opens the mic in recording mode itself, then ends when you say 'stop recording' (or 'finish recording' / 'end recording') — handy for dictating a long instruction hands-free"
+        ]
+      }
+    },
+    {
       "version": "v3.1.31",
       "date": "2026-06-08",
       "changes": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -102,10 +102,10 @@ function App() {
   const [embeddedTerminalMap, setEmbeddedTerminalMap] = useState<Record<string, string>>({});
   // Track which sessions have the terminal pane open: parentSessionId -> boolean
   const [terminalPaneOpenMap, setTerminalPaneOpenMap] = useState<Record<string, boolean>>({});
-  // Mindmap pane open/closed is a single GLOBAL flag (unlike the per-session
-  // terminal pane): it is config-backed and synced across all tabs and remote
-  // clients via the "mindmap:pane" event.
-  const [mindmapPaneOpen, setMindmapPaneOpen] = useState(false);
+  // Mindmap pane open/closed is PER-SESSION (like the terminal pane above):
+  // sessionId -> boolean, kept in local state only. Opening it for one session
+  // must not open it for the others. Ephemeral — resets to closed on restart.
+  const [mindmapPaneOpenMap, setMindmapPaneOpenMap] = useState<Record<string, boolean>>({});
   // Voice is PINNED to the session it was opened on. The single source of truth
   // is the session id voice is attached to (null = voice closed). The pane stays
   // bound to this session even when the user switches the active tab, so it must
@@ -185,14 +185,13 @@ function App() {
     setTerminalPaneOpenMap(prev => ({ ...prev, [activeSession.id]: open }));
   }
 
-  // Toggle the global mindmap pane: update locally for instant feedback, then
-  // persist via the backend, which broadcasts "mindmap:pane" so other tabs and
-  // remote clients converge on the same value.
+  // whether the mindmap pane is open for the active session (per-session, like
+  // the terminal pane above)
+  const activeMindmapPaneOpen = activeSession ? (mindmapPaneOpenMap[activeSession.id] ?? false) : false;
+
   function handleMindmapPaneOpenChange(open: boolean) {
-    setMindmapPaneOpen(open);
-    api.setMindmapPaneOpen(open).catch((err) =>
-      console.error("failed to persist mindmap pane state:", err)
-    );
+    if (!activeSession) return;
+    setMindmapPaneOpenMap(prev => ({ ...prev, [activeSession.id]: open }));
   }
 
   // Tracks which session currently holds a LIVE voice attachment (kicked off),
@@ -434,10 +433,8 @@ function App() {
           setActiveTabId(ids[0]);
           setSelectedSessionId(ids[0]);
         }
-        // Hydrate the global mindmap pane flag from config. Mark hydration as
-        // done so the event handler can safely treat later updates as remote.
-        setMindmapPaneOpen(!!cfg.mindmapPaneOpen);
-        mindmapPaneHydratedRef.current = true;
+        // Mindmap pane open state is per-session and ephemeral now — nothing to
+        // hydrate from config.
         // Hydrate the voice attachment. The Go config only persists the
         // open/closed BOOL; WHICH session is restored from the localStorage
         // companion (this browser), falling back to the persisted active session
@@ -538,12 +535,7 @@ function App() {
     return () => clearTimeout(handle);
   }, [activeWorkspaceId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Guards the initial hydration of the global mindmap pane flag from config,
-  // so the startup read doesn't trigger a write-back (mirrors tabsRestoredRef).
-  const mindmapPaneHydratedRef = useRef(false);
-
-  // Guards the initial hydration of the global voice pane flag from config
-  // (mirrors mindmapPaneHydratedRef).
+  // Guards the initial hydration of the global voice pane flag from config.
   const voicePaneHydratedRef = useRef(false);
 
   // Persist open tabs and active tab to config whenever they change
@@ -772,19 +764,6 @@ function App() {
         });
       }
     );
-    return () => cancel && cancel();
-  }, []);
-
-  // Keep the global mindmap pane flag in sync across every tab and remote
-  // client. The handler is idempotent: it SETS state to the received value and
-  // never toggles, so duplicate/echo events can't flip the pane out of sync.
-  useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const w = window as any;
-    if (!w?.runtime?.EventsOn) return;
-    const cancel = w.runtime.EventsOn("mindmap:pane", (d: { open?: boolean }) => {
-      setMindmapPaneOpen(!!(d && d.open));
-    });
     return () => cancel && cancel();
   }, []);
 
@@ -1374,9 +1353,10 @@ function App() {
     handleOpenTab(sessionId);
     localStorage.setItem("quant.mindmapBoard." + sessionId, board);
     setActiveBoardBySession((prev) => ({ ...prev, [sessionId]: board }));
-    // The mindmap pane open flag is global now: route the OPEN action through
-    // the shared handler so it persists and syncs across tabs/remote clients.
-    handleMindmapPaneOpenChange(true);
+    // Open the mindmap pane for THIS session specifically. We can't go through
+    // handleMindmapPaneOpenChange (which targets the active session) because the
+    // tab we just opened isn't the active session synchronously yet.
+    setMindmapPaneOpenMap((prev) => ({ ...prev, [sessionId]: true }));
   }
 
   // Move a board from one session to another (mirrors session-onto-task move).
@@ -2370,7 +2350,7 @@ function App() {
                 embeddedTerminalSession={activeEmbeddedTerminalSession}
                 terminalPaneOpen={activeTerminalPaneOpen}
                 onTerminalPaneOpenChange={handleTerminalPaneOpenChange}
-                mindmapPaneOpen={mindmapPaneOpen}
+                mindmapPaneOpen={activeMindmapPaneOpen}
                 onMindmapPaneOpenChange={handleMindmapPaneOpenChange}
                 voicePaneOpen={voiceSessionId === activeSession.id}
                 onVoicePaneOpenChange={handleVoicePaneOpenChange}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -261,16 +261,9 @@ export function saveConfig(config: Config): Promise<void> {
   return callGo(PKG, CONFIG_CTRL, "SaveConfig", config);
 }
 
-// Lift the mindmap pane open/close flag to a single global, config-backed
-// value. The backend persists it and emits a "mindmap:pane" event so every
-// session tab and remote client stays in sync.
-export function setMindmapPaneOpen(open: boolean): Promise<void> {
-  return callGo(PKG, CONFIG_CTRL, "SetMindmapPaneOpen", open);
-}
-
 // Lift the voice pane open/close flag to a single global, config-backed value.
-// Mirrors setMindmapPaneOpen: the backend persists it and emits a "voice:pane"
-// event so every session tab and remote client stays in sync.
+// The backend persists it and emits a "voice:pane" event so every session tab
+// and remote client stays in sync.
 export function setVoicePaneOpen(open: boolean): Promise<void> {
   return callGo(PKG, CONFIG_CTRL, "SetVoicePaneOpen", open);
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -609,6 +609,19 @@ export function voiceResultClosed(requestId: string): Promise<void> {
 }
 
 /**
+ * Keepalive for a long-form listen: while the user holds the voice pane in
+ * recording mode, the frontend bridge pings this (~every 30s) with the
+ * in-flight requestId so the Go bridge resets that request's ListenTimeout
+ * timer and the recording isn't cut off mid-speech. Unknown/settled requestIds
+ * are ignored Go-side, and non-recording listens never call this.
+ *
+ * @param requestId correlation id from the "voice:request" event
+ */
+export function voiceListenExtend(requestId: string): Promise<void> {
+  return callGo(VOICE_PKG, VOICE_CTRL, "VoiceListenExtend", requestId);
+}
+
+/**
  * Kick a running session into voice mode. Injects the voice-mode persona/kickoff
  * message into the session (auto-submitted Go-side), after which the agent drives
  * the spoken conversation loop via the voice_* MCP tools. Called once when the

--- a/frontend/src/components/SessionPanel.tsx
+++ b/frontend/src/components/SessionPanel.tsx
@@ -8,6 +8,25 @@ import * as api from "../api";
 
 type SplitLayout = "horizontal" | "vertical";
 
+// Per-session mindmap dock geometry (split layout + divider %), persisted per
+// session in localStorage — mirroring how boards persist under
+// "quant.mindmapBoard.<sessionId>". SessionPanel is a single instance reused
+// across tab switches, so without keying these by session id a resize in one
+// session would silently resize every other session's pane too.
+const MM_LAYOUT_KEY = "quant.mindmapLayout.";
+const MM_DIVIDER_KEY = "quant.mindmapDivider.";
+
+function loadMindmapLayout(sessionId: string): SplitLayout {
+  return localStorage.getItem(MM_LAYOUT_KEY + sessionId) === "horizontal"
+    ? "horizontal"
+    : "vertical";
+}
+
+function loadMindmapDivider(sessionId: string): number {
+  const v = Number(localStorage.getItem(MM_DIVIDER_KEY + sessionId));
+  return Number.isFinite(v) && v >= 20 && v <= 80 ? v : 55;
+}
+
 interface SplitState {
   open: boolean;
   terminalSession: Session | null;
@@ -26,8 +45,8 @@ interface Props {
   embeddedTerminalSession?: Session | null;
   terminalPaneOpen?: boolean;
   onTerminalPaneOpenChange?: (open: boolean) => void;
-  // Mindmap pane open/closed is a single GLOBAL flag owned by App (config-backed,
-  // synced across tabs and remote clients) — not a per-session preference.
+  // Mindmap pane open/closed is a PER-SESSION flag owned by App
+  // (mindmapPaneOpenMap) — ephemeral, every pane starts closed on launch.
   mindmapPaneOpen: boolean;
   onMindmapPaneOpenChange: (open: boolean) => void;
   // Voice pane open/closed is a single GLOBAL flag owned by App (config-backed,
@@ -65,8 +84,13 @@ export function SessionPanel({
   const [menuOpen, setMenuOpen] = useState(false);
   // The mindmap split is independent of the terminal split: it has its own
   // layout (default vertical so the mindmap docks on the right) and divider.
-  const [mindmapLayout, setMindmapLayout] = useState<SplitLayout>("vertical");
-  const [mindmapDividerPercent, setMindmapDividerPercent] = useState(55);
+  // Both are PER-SESSION: hydrated from localStorage whenever the session
+  // changes, persisted back per session id.
+  const [mindmapLayout, setMindmapLayoutState] = useState<SplitLayout>(() => loadMindmapLayout(session.id));
+  const [mindmapDividerPercent, setMindmapDividerPercent] = useState(() => loadMindmapDivider(session.id));
+  // Mirrors the divider state so the mouseup handler can persist the final
+  // value without re-registering listeners on every mousemove.
+  const mindmapDividerRef = useRef(mindmapDividerPercent);
   const menuRef = useRef<HTMLDivElement>(null);
   const splitContainerRef = useRef<HTMLDivElement>(null!)
   const mindmapContainerRef = useRef<HTMLDivElement>(null!)
@@ -90,8 +114,23 @@ export function SessionPanel({
       open: terminalPaneOpen && !!(embeddedTerminalSession || prev.terminalSession),
       terminalSession: embeddedTerminalSession || null,
     }));
-    // NOTE: the mindmap pane open flag is now a global, App-owned value, so
-    // there is nothing session-scoped to reset here.
+    // Hydrate THIS session's mindmap dock geometry (the open flag itself is
+    // per-session App state passed down as a prop).
+    const layout = loadMindmapLayout(session.id);
+    const divider = loadMindmapDivider(session.id);
+    setMindmapLayoutState(layout);
+    setMindmapDividerPercent(divider);
+    mindmapDividerRef.current = divider;
+    // A divider drag must never survive a session switch: the divider element
+    // can unmount mid-drag (pane closed on the next session), which would
+    // leave the dragging flag stuck and let plain mouse movement silently
+    // resize the pane.
+    if (isDraggingMindmap.current || isDragging.current) {
+      isDraggingMindmap.current = false;
+      isDragging.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session.id]);
 
@@ -159,13 +198,20 @@ export function SessionPanel({
       } else {
         percent = ((e.clientX - rect.left) / rect.width) * 100;
       }
-      setMindmapDividerPercent(Math.min(80, Math.max(20, percent)));
+      const clamped = Math.min(80, Math.max(20, percent));
+      mindmapDividerRef.current = clamped;
+      setMindmapDividerPercent(clamped);
     }
     function handleMouseUp() {
       if (!isDraggingMindmap.current) return;
       isDraggingMindmap.current = false;
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
+      // Persist the final divider position for THIS session only.
+      localStorage.setItem(
+        MM_DIVIDER_KEY + session.id,
+        String(Math.round(mindmapDividerRef.current))
+      );
     }
     document.addEventListener("mousemove", handleMouseMove);
     document.addEventListener("mouseup", handleMouseUp);
@@ -173,7 +219,13 @@ export function SessionPanel({
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
     };
-  }, [mindmapLayout]);
+  }, [mindmapLayout, session.id]);
+
+  // Switch the mindmap dock layout and persist it for this session.
+  const setMindmapLayout = useCallback((l: SplitLayout) => {
+    setMindmapLayoutState(l);
+    localStorage.setItem(MM_LAYOUT_KEY + session.id, l);
+  }, [session.id]);
 
   async function handleOpenTerminal() {
     if (splitState.open) return;

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -121,6 +121,16 @@ export function TerminalPane({
       term.onResize(({ rows, cols }) => {
         api.resizeTerminal(sessionIdRef.current, rows, cols).catch(() => {});
       });
+
+      // The fit() at open time ran BEFORE this onResize handler existed, so
+      // the PTY never hears about the grid size the terminal mounted at. When
+      // the terminal is recreated on a tab switch into a pane whose width
+      // differs from this session's last-known PTY size — and the pane does
+      // not change size afterwards (so the ResizeObserver never fires) — the
+      // agent's TUI keeps rendering at the stale column count, squeezing the
+      // chat into a narrow band and leaving an empty gap beside it. Sync the
+      // PTY to the freshly mounted grid explicitly.
+      api.resizeTerminal(sessionIdRef.current, term.rows, term.cols).catch(() => {});
     }
 
     const viewportEl = termContainerRef.current.querySelector('.xterm-viewport');

--- a/frontend/src/components/VoiceOrb.tsx
+++ b/frontend/src/components/VoiceOrb.tsx
@@ -5,7 +5,7 @@ import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
 import { readOrbTheme } from "./voiceOrbTheme";
 
-export type VoiceOrbState = "idle" | "listening" | "thinking" | "speaking";
+export type VoiceOrbState = "idle" | "listening" | "recording" | "thinking" | "speaking";
 
 export interface VoiceOrbProps {
   /** Current orb state. */
@@ -105,7 +105,7 @@ interface StateTarget {
   expandLight?: number;
   rot: number;
   /** which theme accent role drives this state's glow color */
-  role: "accent" | "speak" | "think" | "dim";
+  role: "accent" | "speak" | "think" | "record" | "dim";
 }
 
 const TARGETS: Record<VoiceOrbState, StateTarget> = {
@@ -115,6 +115,10 @@ const TARGETS: Record<VoiceOrbState, StateTarget> = {
   // visible. Kept well under `speaking` (amp 0.155 / expand 0.34) and within the
   // pane frame (the audio-driven geometry term is uAudio*0.10; see VERT).
   listening: { amp: 0.15, freq: 1.9, expand: 0.27, expandLight: 0.16, rot: 0.18, role: "accent" },
+  // Recording = listening pinned open by the user: same mic-reactive feel but a
+  // warmer/red accent (--q-error role) and a slightly stronger base pulse so
+  // it's unmistakably "armed". Still under the speaking flare's envelope.
+  recording: { amp: 0.165, freq: 2.0, expand: 0.3, expandLight: 0.18, rot: 0.2, role: "record" },
   thinking: { amp: 0.1, freq: 2.8, expand: 0.12, rot: 0.55, role: "think" },
   // WI-5.1: speaking is the flare. Reined in ~12-15% from the prototype values
   // (amp 0.18→0.155, expand 0.40→0.34) so the bloom + geometry expansion stay
@@ -231,11 +235,13 @@ export default function VoiceOrb({
     const accentB = new THREE.Color(tokens0.accent);
     const speakB = new THREE.Color(tokens0.speakAccent);
     const thinkB = new THREE.Color(tokens0.thinkAccent);
+    const recordB = new THREE.Color(tokens0.recordAccent);
 
     const colors = {
       accent: { a: darkBase(accentB, isLight), b: accentB.clone() },
       speak: { a: darkBase(speakB, isLight), b: speakB.clone() },
       think: { a: darkBase(thinkB, isLight), b: thinkB.clone() },
+      record: { a: darkBase(recordB, isLight), b: recordB.clone() },
       dim: { a: darkBase(accentB, isLight), b: accentB.clone().multiplyScalar(isLight ? 0.7 : 0.55) },
     };
 
@@ -316,6 +322,8 @@ export default function VoiceOrb({
       colors.speak.a.copy(darkBase(colors.speak.b, isLight));
       colors.think.b.set(t.thinkAccent);
       colors.think.a.copy(darkBase(colors.think.b, isLight));
+      colors.record.b.set(t.recordAccent);
+      colors.record.a.copy(darkBase(colors.record.b, isLight));
       colors.dim.b.copy(new THREE.Color(t.accent).multiplyScalar(isLight ? 0.7 : 0.55));
       colors.dim.a.copy(darkBase(new THREE.Color(t.accent), isLight));
     };
@@ -357,6 +365,8 @@ export default function VoiceOrb({
           ? colors.speak
           : tg.role === "think"
           ? colors.think
+          : tg.role === "record"
+          ? colors.record
           : tg.role === "dim"
           ? colors.dim
           : colors.accent;
@@ -383,7 +393,8 @@ export default function VoiceOrb({
       // True only when a real live level (mic/output) is driving the orb. The
       // simulated/fallback path (harness, idle, thinking, missing getLevel) keeps
       // the original symmetric smoothing so its visual baselines are unchanged.
-      const driven = provided !== null && (s === "listening" || s === "speaking");
+      const driven =
+        provided !== null && (s === "listening" || s === "recording" || s === "speaking");
       if (driven) {
         raw = provided as number;
       } else if (s === "speaking") {
@@ -394,6 +405,11 @@ export default function VoiceOrb({
         raw = isLight
           ? 0.07 + 0.08 * Math.abs(Math.sin(t * 3.1))
           : 0.18 + 0.16 * Math.abs(Math.sin(t * 3.1));
+      } else if (s === "recording") {
+        // Fallback envelope (harness/no mic): like listening, a touch stronger.
+        raw = isLight
+          ? 0.1 + 0.1 * Math.abs(Math.sin(t * 3.4))
+          : 0.22 + 0.18 * Math.abs(Math.sin(t * 3.4));
       } else {
         raw = 0.04 + 0.03 * Math.sin(t * 1.2);
       }

--- a/frontend/src/components/VoicePane.tsx
+++ b/frontend/src/components/VoicePane.tsx
@@ -797,8 +797,8 @@ export function VoicePane({ sessionId, className, style }: Props) {
               onClick={handleToggleRecording}
               title={
                 state === "recording"
-                  ? "stop recording and send the full transcript"
-                  : "record a long message (keeps listening across pauses until you stop)"
+                  ? "stop recording and send the full transcript (you can also say 'stop recording')"
+                  : "record a long message (keeps listening across pauses until you tap stop or say 'stop recording')"
               }
               style={{
                 flex: "none",

--- a/frontend/src/components/VoicePane.tsx
+++ b/frontend/src/components/VoicePane.tsx
@@ -144,6 +144,11 @@ export function VoicePane({ sessionId, className, style }: Props) {
   const [meterLevel, setMeterLevel] = useState(0);
   // Seconds elapsed in the current recording (drives the mm:ss indicator).
   const [recordSecs, setRecordSecs] = useState(0);
+  // Live draft transcript while recording: the accumulated text so far, grown
+  // segment by segment as each STT resolves (onRecordingTranscript). Rendered
+  // as an in-progress `you ▸` line; removed when the final transcript line
+  // lands (onUserTranscript) so there's never a duplicate.
+  const [draft, setDraft] = useState("");
 
   const serviceRef = useRef<IAudioService | null>(null);
   // Live mirror of `state` for the orb's per-frame level callback (avoids stale
@@ -258,11 +263,18 @@ export function VoicePane({ sessionId, className, style }: Props) {
       // an extra re-render the orb ignores).
       const offState = service.onState((s) => setState(s));
       const offError = service.onError((e) => setError(e));
+      // Live recording draft: the service emits the accumulated transcript as
+      // each segment's STT resolves ("" on reset → clears the draft).
+      const offRecTranscript = service.onRecordingTranscript((text) => setDraft(text));
 
       // Bridge: Go MCP voice tools → this pane's audio service. The transcript
       // callbacks surface each turn into the conversation view.
       const offBridge = registerVoiceBridge(sessionId, service, {
-        onUserTranscript: (text) => addLine("you", text),
+        onUserTranscript: (text) => {
+          // The final line replaces the in-progress draft (no duplicate).
+          setDraft("");
+          addLine("you", text);
+        },
         onAgentSpeak: (text) => addLine("quant", text),
       });
 
@@ -314,6 +326,7 @@ export function VoicePane({ sessionId, className, style }: Props) {
         offBridge();
         offState();
         offError();
+        offRecTranscript();
         void service.dispose();
         serviceRef.current = null;
       });
@@ -406,11 +419,24 @@ export function VoicePane({ sessionId, className, style }: Props) {
     return () => clearInterval(t);
   }, [state]);
 
-  // Keep the newest transcript line in view (scroll to bottom on append).
+  // The draft only makes sense while recording (and through the brief
+  // "thinking" after stop, until the final line arrives). Any other state means
+  // the turn ended some other way (cancel/error/no speech) — drop the draft.
+  useEffect(() => {
+    if (state !== "recording" && state !== "thinking") setDraft("");
+  }, [state]);
+
+  // The in-progress recording draft, shown while recording + the post-stop
+  // thinking beat. Empty (no segment recognized yet / user never spoke) → no
+  // draft line at all.
+  const showDraft = !!draft.trim() && (state === "recording" || state === "thinking");
+
+  // Keep the newest transcript line in view (scroll to bottom on append —
+  // including when the live draft appears/grows).
   useEffect(() => {
     const el = transcriptRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [lines]);
+  }, [lines, draft, showDraft]);
 
   // (The "voice not configured" gate is derived in the service-init effect above
   // from the same getConfig() it already performs — see setNotConfigured there.)
@@ -489,7 +515,7 @@ export function VoicePane({ sessionId, className, style }: Props) {
           gap: 8,
         }}
       >
-        {lines.length === 0 ? (
+        {lines.length === 0 && !showDraft ? (
           <div
             style={{
               color: "var(--q-fg-muted)",
@@ -518,31 +544,72 @@ export function VoicePane({ sessionId, className, style }: Props) {
             )}
           </div>
         ) : (
-          lines.map((line) => (
-            <div key={line.id} style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
-              <span
+          <>
+            {lines.map((line) => (
+              <div key={line.id} style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
+                <span
+                  style={{
+                    flex: "none",
+                    fontSize: 11,
+                    fontWeight: 700,
+                    color: line.who === "you" ? "var(--q-accent)" : "var(--q-term-green)",
+                  }}
+                >
+                  {line.who} ▸
+                </span>
+                <span
+                  style={{
+                    fontSize: 12.5,
+                    lineHeight: 1.5,
+                    color: "var(--q-fg)",
+                    overflowWrap: "anywhere",
+                    whiteSpace: "pre-wrap",
+                  }}
+                >
+                  {line.text}
+                </span>
+              </div>
+            ))}
+            {/* Live recording draft: same `you ▸` layout as a real line, but
+                dimmed + italic to read as in-progress. It grows as each speech
+                segment is transcribed and is replaced by the final line on stop. */}
+            {showDraft && (
+              <div
                 style={{
-                  flex: "none",
-                  fontSize: 11,
-                  fontWeight: 700,
-                  color: line.who === "you" ? "var(--q-accent)" : "var(--q-term-green)",
+                  display: "flex",
+                  gap: 8,
+                  alignItems: "baseline",
+                  opacity: 0.72,
                 }}
               >
-                {line.who} ▸
-              </span>
-              <span
-                style={{
-                  fontSize: 12.5,
-                  lineHeight: 1.5,
-                  color: "var(--q-fg)",
-                  overflowWrap: "anywhere",
-                  whiteSpace: "pre-wrap",
-                }}
-              >
-                {line.text}
-              </span>
-            </div>
-          ))
+                <span
+                  style={{
+                    flex: "none",
+                    fontSize: 11,
+                    fontWeight: 700,
+                    color: "var(--q-accent)",
+                  }}
+                >
+                  you ▸
+                </span>
+                <span
+                  style={{
+                    fontSize: 12.5,
+                    lineHeight: 1.5,
+                    fontStyle: "italic",
+                    color: "var(--q-fg-secondary)",
+                    overflowWrap: "anywhere",
+                    whiteSpace: "pre-wrap",
+                  }}
+                >
+                  {draft}
+                  <span style={{ color: "var(--q-fg-muted)", fontStyle: "normal" }}>
+                    {state === "recording" ? " · listening…" : " · finishing…"}
+                  </span>
+                </span>
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/frontend/src/components/VoicePane.tsx
+++ b/frontend/src/components/VoicePane.tsx
@@ -44,6 +44,7 @@ interface Props {
 const STATE_LABEL: Record<VoiceServiceState, string> = {
   idle: "idle",
   listening: "listening",
+  recording: "recording",
   thinking: "thinking",
   speaking: "speaking",
 };
@@ -52,9 +53,17 @@ const STATE_LABEL: Record<VoiceServiceState, string> = {
 const STATE_COLOR: Record<VoiceServiceState, string> = {
   idle: "var(--q-fg-muted)",
   listening: "var(--q-accent)",
+  recording: "var(--q-error)",
   thinking: "var(--q-blue)",
   speaking: "var(--q-term-green)",
 };
+
+/** mm:ss for the recording elapsed indicator. */
+function formatElapsed(totalSecs: number): string {
+  const m = Math.floor(totalSecs / 60);
+  const s = totalSecs % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
 
 // WI-5.5: map an error kind to an actionable, human banner. `title` is short
 // (status bar), `detail` is the actionable line, `action` (optional) hints what
@@ -133,6 +142,8 @@ export function VoicePane({ sessionId, className, style }: Props) {
   const [hasLabels, setHasLabels] = useState(true);
   // 0..METER_SEGMENTS-1 lit segments, driven by getInputLevel() via rAF.
   const [meterLevel, setMeterLevel] = useState(0);
+  // Seconds elapsed in the current recording (drives the mm:ss indicator).
+  const [recordSecs, setRecordSecs] = useState(0);
 
   const serviceRef = useRef<IAudioService | null>(null);
   // Live mirror of `state` for the orb's per-frame level callback (avoids stale
@@ -368,6 +379,32 @@ export function VoicePane({ sessionId, className, style }: Props) {
       }
     })();
   };
+
+  // Toggle long-form recording on the active listen turn. Start is sync; stop
+  // flushes/joins the segments and resolves the listen (state → thinking).
+  const handleToggleRecording = () => {
+    const svc = serviceRef.current;
+    if (!svc) return;
+    if (svc.isRecording()) {
+      void svc.stopRecording();
+    } else {
+      svc.startRecording();
+    }
+  };
+
+  // Tick the mm:ss elapsed indicator while recording.
+  useEffect(() => {
+    if (state !== "recording") {
+      setRecordSecs(0);
+      return;
+    }
+    const startedAt = Date.now();
+    setRecordSecs(0);
+    const t = setInterval(() => {
+      setRecordSecs(Math.floor((Date.now() - startedAt) / 1000));
+    }, 1000);
+    return () => clearInterval(t);
+  }, [state]);
 
   // Keep the newest transcript line in view (scroll to bottom on append).
   useEffect(() => {
@@ -684,6 +721,53 @@ export function VoicePane({ sessionId, className, style }: Props) {
           <span style={{ fontSize: 10.5, color: "var(--q-fg-secondary)" }}>
             {STATE_LABEL[state]}
           </span>
+
+          {/* Record toggle: visible while a listen turn is active. Pressing it
+              pins the turn open (recording: speak as long as you want, across
+              pauses); pressing again stops + finalizes the full transcript. */}
+          {(state === "listening" || state === "recording") && (
+            <button
+              onClick={handleToggleRecording}
+              title={
+                state === "recording"
+                  ? "stop recording and send the full transcript"
+                  : "record a long message (keeps listening across pauses until you stop)"
+              }
+              style={{
+                flex: "none",
+                marginLeft: 8,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 5,
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: 10.5,
+                color: "var(--q-error)",
+                backgroundColor: "var(--q-bg-hover)",
+                border:
+                  state === "recording"
+                    ? "1px solid var(--q-error)"
+                    : "1px solid var(--q-border)",
+                borderRadius: 4,
+                padding: "1px 6px",
+                cursor: "pointer",
+              }}
+            >
+              {state === "recording" ? (
+                <>
+                  <span style={{ fontSize: 9, lineHeight: 1 }}>■</span>
+                  stop
+                  <span style={{ color: "var(--q-fg-secondary)" }}>
+                    {formatElapsed(recordSecs)}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span style={{ fontSize: 9, lineHeight: 1 }}>●</span>
+                  rec
+                </>
+              )}
+            </button>
+          )}
         </div>
 
         {error ? (

--- a/frontend/src/components/voiceOrbTheme.ts
+++ b/frontend/src/components/voiceOrbTheme.ts
@@ -17,6 +17,8 @@ export interface OrbThemeTokens {
   speakAccent: string;
   /** Accent used for the "thinking" state (falls back to a warm tone / accent). */
   thinkAccent: string;
+  /** Accent used for the "recording" state (red-tinted; falls back to accent). */
+  recordAccent: string;
   /** True when the app background is light -> use the light-theme glow recipe. */
   isLight: boolean;
 }
@@ -83,12 +85,15 @@ export function readOrbTheme(el?: HTMLElement | null): OrbThemeTokens {
   const speakAccent = get("--q-blue", get("--q-cyan", accent));
   // --q-warning gives the "thinking" warm tone; fall back to accent.
   const thinkAccent = get("--q-warning", accent);
+  // --q-error gives the "recording" warm/red tone; fall back to accent.
+  const recordAccent = get("--q-error", accent);
 
   return {
     accent,
     bg,
     speakAccent,
     thinkAccent,
+    recordAccent,
     isLight: isLightColor(bg),
   };
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -248,7 +248,6 @@ export interface Config {
   idleTimeoutMinutes: number;
   activeSessionId: string;
   openSessionIds: string[];
-  mindmapPaneOpen: boolean;
   voicePaneOpen: boolean;
 
   // Storage & Data

--- a/frontend/src/voice/audioService.dev.tsx
+++ b/frontend/src/voice/audioService.dev.tsx
@@ -33,9 +33,14 @@ const STATES: VoiceServiceState[] = ["idle", "listening", "thinking", "speaking"
 
 // Mock transport — used by default in the harness. Toggleable to the real
 // api.ts transport via the URL flag `?real=1` (won't work outside the app).
+// Tests can push strings onto window.__voiceTranscriptQueue to script what the
+// next transcribe() calls return (e.g. a recording segment ending in a stop
+// phrase); when the queue is empty the fixed marker is returned.
 function makeMockTransport(): VoiceTransport {
   return {
     async transcribe() {
+      const q = window.__voiceTranscriptQueue;
+      if (Array.isArray(q) && q.length > 0) return q.shift()!;
       // Fixed marker so Playwright can assert deterministically.
       return "VOICE_TRANSCRIPT_MARKER";
     },
@@ -51,6 +56,8 @@ declare global {
     __voiceState?: string;
     __voiceTranscript?: string;
     __voiceError?: string | null;
+    /** Scripted transcribe() results for tests (shifted per call; empty → marker). */
+    __voiceTranscriptQueue?: string[];
   }
 }
 

--- a/frontend/src/voice/audioService.ts
+++ b/frontend/src/voice/audioService.ts
@@ -30,6 +30,15 @@ const DEFAULT_VAD_ASSET_PATH = "/vad/";
 // timeout). Generous so a long, paused explanation isn't cut off by the ceiling;
 // the redemption window (above) handles normal turn-taking well before this.
 const DEFAULT_MAX_LISTEN_MS = 60_000;
+// Safety ceiling for an explicit recording (user-pinned listen). Recording is
+// only ended by the user's stop, so this just guards against a forgotten
+// recording holding the mic forever; on expiry it finalizes with whatever was
+// captured so far.
+const RECORDING_MAX_MS = 15 * 60_000;
+// After flushing a mid-speech segment on stopRecording (vad.pause with
+// submitUserSpeechOnPause), give the onSpeechEnd callback a beat to enqueue its
+// transcription before we snapshot the segment list.
+const RECORDING_FLUSH_GRACE_MS = 80;
 /** Barge-in is suppressed for this long after TTS playback starts (see handleSpeechStart). */
 const BARGE_IN_GUARD_MS = 1200;
 /**
@@ -219,6 +228,14 @@ export class AudioService implements IAudioService {
     timer: ReturnType<typeof setTimeout> | null;
     settled: boolean;
   } | null = null;
+
+  // Recording mode (user-pinned listen). While active, handleSpeechEnd
+  // transcribes each VAD segment immediately (ordered promises below) instead
+  // of resolving the pending listen; stopRecording() joins them and resolves.
+  private recordingActive = false;
+  private recordingStopping = false;
+  private recordingSegments: Promise<string>[] = [];
+  private recordingCeil: ReturnType<typeof setTimeout> | null = null;
 
   // One in-flight speak() at a time.
   private pendingSpeak: {
@@ -758,12 +775,30 @@ export class AudioService implements IAudioService {
       return;
     }
     if (this.pendingListen) {
-      this.setState("listening");
+      this.setState(this.recordingActive ? "recording" : "listening");
     }
   }
 
   private async handleSpeechEnd(audio: Float32Array) {
     if (!this.pendingListen || this.pendingListen.settled) return;
+
+    if (this.recordingActive) {
+      // Recording: do NOT resolve the listen. Transcribe this segment right
+      // away (keeps the final stop fast and avoids one giant WAV) and keep the
+      // VAD running for the next segment. A failed segment resolves to "" so a
+      // single STT hiccup is skipped instead of killing the whole recording.
+      let audioB64: string;
+      try {
+        const wav = utils.encodeWAV(audio); // defaults: PCM, 16000Hz, mono, 16-bit
+        audioB64 = utils.arrayBufferToBase64(wav);
+      } catch {
+        return; // skip the segment; keep recording
+      }
+      this.recordingSegments.push(
+        this.transport.transcribe(audioB64, "audio/wav").catch(() => ""),
+      );
+      return;
+    }
 
     // Stop the VAD: we want exactly one utterance per listen().
     try {
@@ -801,7 +836,7 @@ export class AudioService implements IAudioService {
   private handleVADMisfire() {
     // Spoke too briefly to count; keep listening (stay in the same state).
     if (this.pendingListen && !this.pendingListen.settled) {
-      this.setState("listening");
+      this.setState(this.recordingActive ? "recording" : "listening");
     }
   }
 
@@ -881,12 +916,108 @@ export class AudioService implements IAudioService {
     this.failListen({ kind: "unknown", message: "Listen cancelled." });
   }
 
+  // ---- recording (user-pinned long-form listen) ------------------------------
+
+  isRecording(): boolean {
+    return this.recordingActive;
+  }
+
+  startRecording(): void {
+    const p = this.pendingListen;
+    if (!p || p.settled || this.recordingActive) return;
+
+    // Disarm the per-listen maxListenMs timeout: the user explicitly owns the
+    // turn now. A generous safety ceiling replaces it (finalizes with whatever
+    // was captured if the user walks away).
+    if (p.timer) {
+      clearTimeout(p.timer);
+      p.timer = null;
+    }
+    this.recordingActive = true;
+    this.recordingStopping = false;
+    this.recordingSegments = [];
+    // Make vad.pause() flush a mid-speech segment via onSpeechEnd, so the user
+    // can hit stop without waiting out the redemption window. Recording-only:
+    // reset in resetRecording() so normal listens keep today's pause semantics.
+    try {
+      this.vad?.setOptions({ submitUserSpeechOnPause: true });
+    } catch {
+      /* ignore — stop falls back to whatever the VAD has endpointed */
+    }
+    this.recordingCeil = setTimeout(() => {
+      this.recordingCeil = null;
+      void this.stopRecording();
+    }, RECORDING_MAX_MS);
+    this.setState("recording");
+  }
+
+  async stopRecording(): Promise<void> {
+    if (!this.recordingActive || this.recordingStopping) return;
+    this.recordingStopping = true;
+    if (this.recordingCeil) {
+      clearTimeout(this.recordingCeil);
+      this.recordingCeil = null;
+    }
+
+    // Flush a mid-speech segment: with submitUserSpeechOnPause, pause() emits a
+    // final onSpeechEnd carrying whatever has been captured so far (it lands in
+    // recordingSegments via the recording branch above, which is still active).
+    try {
+      await this.vad?.pause();
+    } catch {
+      /* ignore */
+    }
+    await new Promise((r) => setTimeout(r, RECORDING_FLUSH_GRACE_MS));
+
+    const segments = this.recordingSegments;
+    const p = this.pendingListen;
+    this.resetRecording();
+    if (!p || p.settled) return; // listen was cancelled mid-stop
+
+    // STT for the tail segments is (possibly) still in flight.
+    this.setState("thinking");
+    const texts = await Promise.all(segments); // segment failures resolved to ""
+    if (!this.pendingListen || this.pendingListen.settled) return;
+    const transcript = texts
+      .map((t) => t.trim())
+      .filter(Boolean)
+      .join("\n");
+    if (!transcript) {
+      // Recording was toggled but nothing was captured/recognized — behave like
+      // the existing no-speech path (the bridge maps "timeout" to an empty
+      // transcript so the agent gets the "no speech heard" nudge, not an error).
+      this.failListen({
+        kind: "timeout",
+        message: `No speech was captured while recording. [${this.listenDiag()}]`,
+      });
+      return;
+    }
+    this.resolveListen(transcript);
+  }
+
+  /** Clear all recording state (also invoked when a listen settles/fails). */
+  private resetRecording(): void {
+    this.recordingActive = false;
+    this.recordingStopping = false;
+    this.recordingSegments = [];
+    if (this.recordingCeil) {
+      clearTimeout(this.recordingCeil);
+      this.recordingCeil = null;
+    }
+    try {
+      this.vad?.setOptions({ submitUserSpeechOnPause: false });
+    } catch {
+      /* ignore */
+    }
+  }
+
   private resolveListen(transcript: string) {
     const p = this.pendingListen;
     if (!p || p.settled) return;
     p.settled = true;
     if (p.timer) clearTimeout(p.timer);
     this.clearListenSampler();
+    if (this.recordingActive) this.resetRecording();
     this.pendingListen = null;
     try {
       this.vad?.pause();
@@ -911,6 +1042,7 @@ export class AudioService implements IAudioService {
     p.settled = true;
     if (p.timer) clearTimeout(p.timer);
     this.clearListenSampler();
+    if (this.recordingActive) this.resetRecording();
     this.pendingListen = null;
     try {
       this.vad?.pause();

--- a/frontend/src/voice/audioService.ts
+++ b/frontend/src/voice/audioService.ts
@@ -17,6 +17,7 @@ import type {
   AudioServiceOptions,
   DevicesChangedCb,
   IAudioService,
+  ListenOptions,
   RecordingTranscriptCb,
   VadTuning,
   VoiceError,
@@ -42,6 +43,20 @@ const RECORDING_MAX_MS = 15 * 60_000;
 const RECORDING_FLUSH_GRACE_MS = 80;
 /** Barge-in is suppressed for this long after TTS playback starts (see handleSpeechStart). */
 const BARGE_IN_GUARD_MS = 1200;
+// Hands-free stop phrases for recording mode. When a recording segment's STT
+// result ENDS with one of these (case-insensitive, trailing punctuation
+// ignored), the phrase is stripped from the segment and the recording is
+// finalized exactly as if the user pressed "■ stop". Matching is deliberately
+// conservative: the phrase must be the END of the segment (a whole-word tail),
+// so mentioning "stop recording" mid-sentence never cuts a dictation short.
+const RECORDING_STOP_PHRASES = [
+  "stop recording",
+  "stop the recording",
+  "end recording",
+  "end the recording",
+  "finish recording",
+  "stop dictation",
+] as const;
 /**
  * Upper bound the orb stays in the post-listen "thinking" state after STT
  * resolves while the agent reasons (and may run tools), before the next
@@ -151,6 +166,32 @@ function joinSegmentTexts(texts: ReadonlyArray<string | null>): string {
     .map((t) => (t ?? "").trim())
     .filter(Boolean)
     .join("\n");
+}
+
+/**
+ * Detect a hands-free stop phrase at the END of a recording segment's
+ * transcript. Returns the segment text with the phrase (and any separating /
+ * trailing punctuation) stripped, plus whether a phrase matched. A segment that
+ * is ONLY the stop phrase strips to "" (the slot is dropped by
+ * joinSegmentTexts). The phrase must be a whole-word tail — "nonstop recording"
+ * does not match.
+ */
+function stripStopPhrase(text: string): { text: string; matched: boolean } {
+  // Ignore trailing whitespace + punctuation (STT often appends "." or "!").
+  const trimmed = text.replace(/[\s.,!?…;:]+$/u, "");
+  const lower = trimmed.toLowerCase();
+  for (const phrase of RECORDING_STOP_PHRASES) {
+    if (!lower.endsWith(phrase)) continue;
+    const cut = trimmed.length - phrase.length;
+    // Whole-word tail only: the phrase must start the string or follow a
+    // non-alphanumeric character.
+    if (cut > 0 && /[a-z0-9]/i.test(trimmed[cut - 1])) continue;
+    // Keep the prefix, dropping the punctuation/whitespace that separated it
+    // from the phrase ("…and that's all, stop recording" → "…and that's all").
+    const prefix = trimmed.slice(0, cut).replace(/[\s.,!?…;:—–-]+$/u, "");
+    return { text: prefix, matched: true };
+  }
+  return { text, matched: false };
 }
 
 /** Default transport = the real Wails-bridged api.ts wrappers. */
@@ -840,19 +881,33 @@ export class AudioService implements IAudioService {
       const slot = this.recordingSlotTexts.length;
       const epoch = this.recordingEpoch;
       this.recordingSlotTexts.push(null);
-      const p = this.transport.transcribe(audioB64, "audio/wav").catch(() => "");
+      // The pushed segment promise resolves to the text AFTER stop-phrase
+      // stripping, so stopRecording()'s final join and the live transcript see
+      // the same per-segment results (a segment that was only the stop phrase
+      // strips to "" and is dropped by joinSegmentTexts).
+      const p = this.transport
+        .transcribe(audioB64, "audio/wav")
+        .catch(() => "")
+        .then((raw) => {
+          const { text, matched } = stripStopPhrase(raw);
+          // Live transcript: as each segment resolves, fill its slot and emit
+          // the accumulated join so the pane can show the draft growing in real
+          // time. Empty/failed segments change nothing, so emit nothing for
+          // them. A stale resolution (recording reset/stopped meanwhile) is
+          // dropped.
+          if (epoch === this.recordingEpoch) {
+            this.recordingSlotTexts[slot] = text;
+            if (text.trim()) {
+              this.emitRecordingTranscript(joinSegmentTexts(this.recordingSlotTexts));
+            }
+            // Hands-free stop: the segment ended with a stop phrase → finalize
+            // as if "■ stop" was pressed. stopRecording() itself guards against
+            // re-entrancy via recordingStopping.
+            if (matched) void this.stopRecording();
+          }
+          return text;
+        });
       this.recordingSegments.push(p);
-      // Live transcript: as each segment resolves, fill its slot and emit the
-      // accumulated join so the pane can show the draft growing in real time.
-      // Empty/failed segments change nothing, so emit nothing for them. A
-      // stale resolution (recording reset/stopped meanwhile) is dropped.
-      void p.then((text) => {
-        if (epoch !== this.recordingEpoch) return;
-        this.recordingSlotTexts[slot] = text;
-        if (text.trim()) {
-          this.emitRecordingTranscript(joinSegmentTexts(this.recordingSlotTexts));
-        }
-      });
       return;
     }
 
@@ -898,7 +953,7 @@ export class AudioService implements IAudioService {
 
   // ---- listen() ------------------------------------------------------------
 
-  async listen(): Promise<string> {
+  async listen(opts?: ListenOptions): Promise<string> {
     // Only one listen at a time; cancel any prior.
     if (this.pendingListen && !this.pendingListen.settled) {
       this.cancelListen();
@@ -933,9 +988,18 @@ export class AudioService implements IAudioService {
 
       this.pendingListen = { resolve, reject, timer, settled: false };
 
-      // Begin capturing. We surface "listening" immediately so the orb reacts
-      // to mic level even before the first speech-start fires.
-      this.setState("listening");
+      if (opts?.record) {
+        // Agent-activated recording: pin the turn open BEFORE the VAD starts so
+        // the user can dictate hands-free from the first word. startRecording()
+        // requires pendingListen (just armed above); it disarms the maxListenMs
+        // timer, arms the recording safety ceiling, and sets state "recording"
+        // — so we skip the "listening" transition below entirely.
+        this.startRecording();
+      } else {
+        // Begin capturing. We surface "listening" immediately so the orb reacts
+        // to mic level even before the first speech-start fires.
+        this.setState("listening");
+      }
       try {
         this.vad!.start();
       } catch (e) {

--- a/frontend/src/voice/audioService.ts
+++ b/frontend/src/voice/audioService.ts
@@ -17,6 +17,7 @@ import type {
   AudioServiceOptions,
   DevicesChangedCb,
   IAudioService,
+  RecordingTranscriptCb,
   VadTuning,
   VoiceError,
   VoiceErrorCb,
@@ -138,6 +139,20 @@ function resolveVadOptions(
   };
 }
 
+/**
+ * Join recording segment texts into the final transcript: trim each, drop
+ * empties (failed segments resolve to ""), newline-separate. `null` slots
+ * (STT still in flight) are simply omitted. Used by BOTH the live
+ * onRecordingTranscript emission and stopRecording()'s final resolve so the
+ * two can never diverge.
+ */
+function joinSegmentTexts(texts: ReadonlyArray<string | null>): string {
+  return texts
+    .map((t) => (t ?? "").trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
 /** Default transport = the real Wails-bridged api.ts wrappers. */
 const defaultTransport: VoiceTransport = {
   transcribe: (audioB64, mime) => api.transcribe(audioB64, mime),
@@ -235,7 +250,18 @@ export class AudioService implements IAudioService {
   private recordingActive = false;
   private recordingStopping = false;
   private recordingSegments: Promise<string>[] = [];
+  // Per-slot resolved segment texts, in SPEECH order (slot = push index above).
+  // `null` = the segment's STT is still in flight. The live transcript emitted
+  // via onRecordingTranscript is joinSegmentTexts() over this array, so an
+  // out-of-order STT resolution can only ever fill in an earlier/later slot —
+  // never reorder the text. stopRecording()'s final join uses the same helper
+  // over the same per-segment results so live and final cannot diverge.
+  private recordingSlotTexts: (string | null)[] = [];
+  // Bumped on every reset so a stale segment promise resolving after the
+  // recording ended (or a new one started) can't emit into the wrong recording.
+  private recordingEpoch = 0;
   private recordingCeil: ReturnType<typeof setTimeout> | null = null;
+  private readonly recordingTranscriptCbs = new Set<RecordingTranscriptCb>();
 
   // One in-flight speak() at a time.
   private pendingSpeak: {
@@ -268,6 +294,21 @@ export class AudioService implements IAudioService {
   onError(cb: VoiceErrorCb): () => void {
     this.errorCbs.add(cb);
     return () => this.errorCbs.delete(cb);
+  }
+
+  onRecordingTranscript(cb: RecordingTranscriptCb): () => void {
+    this.recordingTranscriptCbs.add(cb);
+    return () => this.recordingTranscriptCbs.delete(cb);
+  }
+
+  private emitRecordingTranscript(text: string) {
+    for (const cb of this.recordingTranscriptCbs) {
+      try {
+        cb(text);
+      } catch {
+        /* never let a subscriber break the pipeline */
+      }
+    }
   }
 
   getState(): VoiceServiceState {
@@ -794,9 +835,24 @@ export class AudioService implements IAudioService {
       } catch {
         return; // skip the segment; keep recording
       }
-      this.recordingSegments.push(
-        this.transport.transcribe(audioB64, "audio/wav").catch(() => ""),
-      );
+      // Slot index = speech order (this branch is synchronous up to here, so
+      // pushes happen in endpoint order even though STT resolves out of order).
+      const slot = this.recordingSlotTexts.length;
+      const epoch = this.recordingEpoch;
+      this.recordingSlotTexts.push(null);
+      const p = this.transport.transcribe(audioB64, "audio/wav").catch(() => "");
+      this.recordingSegments.push(p);
+      // Live transcript: as each segment resolves, fill its slot and emit the
+      // accumulated join so the pane can show the draft growing in real time.
+      // Empty/failed segments change nothing, so emit nothing for them. A
+      // stale resolution (recording reset/stopped meanwhile) is dropped.
+      void p.then((text) => {
+        if (epoch !== this.recordingEpoch) return;
+        this.recordingSlotTexts[slot] = text;
+        if (text.trim()) {
+          this.emitRecordingTranscript(joinSegmentTexts(this.recordingSlotTexts));
+        }
+      });
       return;
     }
 
@@ -936,6 +992,10 @@ export class AudioService implements IAudioService {
     this.recordingActive = true;
     this.recordingStopping = false;
     this.recordingSegments = [];
+    this.recordingSlotTexts = [];
+    this.recordingEpoch++;
+    // A new recording always starts with a clean live draft.
+    this.emitRecordingTranscript("");
     // Make vad.pause() flush a mid-speech segment via onSpeechEnd, so the user
     // can hit stop without waiting out the redemption window. Recording-only:
     // reset in resetRecording() so normal listens keep today's pause semantics.
@@ -971,17 +1031,18 @@ export class AudioService implements IAudioService {
 
     const segments = this.recordingSegments;
     const p = this.pendingListen;
-    this.resetRecording();
+    // Keep the live draft on screen through the post-stop "thinking" beat: the
+    // pane removes it when the final transcript line arrives, so don't emit a
+    // clear here (a NEW recording still starts clean via startRecording()).
+    this.resetRecording(false);
     if (!p || p.settled) return; // listen was cancelled mid-stop
 
     // STT for the tail segments is (possibly) still in flight.
     this.setState("thinking");
     const texts = await Promise.all(segments); // segment failures resolved to ""
     if (!this.pendingListen || this.pendingListen.settled) return;
-    const transcript = texts
-      .map((t) => t.trim())
-      .filter(Boolean)
-      .join("\n");
+    // Same per-segment results + join as the live onRecordingTranscript path.
+    const transcript = joinSegmentTexts(texts);
     if (!transcript) {
       // Recording was toggled but nothing was captured/recognized — behave like
       // the existing no-speech path (the bridge maps "timeout" to an empty
@@ -995,11 +1056,20 @@ export class AudioService implements IAudioService {
     this.resolveListen(transcript);
   }
 
-  /** Clear all recording state (also invoked when a listen settles/fails). */
-  private resetRecording(): void {
+  /**
+   * Clear all recording state (also invoked when a listen settles/fails).
+   * Emits an empty live transcript by default so the pane's draft is cleared;
+   * stopRecording() passes false to keep the draft visible until the final
+   * transcript line lands.
+   */
+  private resetRecording(emitClear = true): void {
     this.recordingActive = false;
     this.recordingStopping = false;
     this.recordingSegments = [];
+    this.recordingSlotTexts = [];
+    // Invalidate any still-in-flight segment resolutions for the old recording.
+    this.recordingEpoch++;
+    if (emitClear) this.emitRecordingTranscript("");
     if (this.recordingCeil) {
       clearTimeout(this.recordingCeil);
       this.recordingCeil = null;

--- a/frontend/src/voice/types.ts
+++ b/frontend/src/voice/types.ts
@@ -120,6 +120,18 @@ export interface VadTuning {
   minSpeechMs?: number;
 }
 
+/** Options for a single listen() turn. */
+export interface ListenOptions {
+  /**
+   * Start the listen already pinned open in recording mode (long-form
+   * dictation): equivalent to calling startRecording() the instant the turn is
+   * armed, so the user never has to tap "rec". The turn then only resolves on
+   * an explicit stop (stopRecording(), the spoken stop phrase, or the
+   * recording safety ceiling). Default false — a normal single-utterance turn.
+   */
+  record?: boolean;
+}
+
 /** A selectable audio input (microphone). */
 export interface AudioInputDevice {
   deviceId: string;
@@ -149,8 +161,10 @@ export interface IAudioService {
   /**
    * Capture one VAD-endpointed utterance, run STT, resolve with the transcript.
    * Opens the mic if needed. Honors maxListenMs. Rejects on error/cancel.
+   * With `opts.record` the turn starts already in recording mode (see
+   * ListenOptions / startRecording()).
    */
-  listen(): Promise<string>;
+  listen(opts?: ListenOptions): Promise<string>;
 
   /** Cancel an in-flight listen() (rejects its promise with a cancel error). */
   cancelListen(): void;

--- a/frontend/src/voice/types.ts
+++ b/frontend/src/voice/types.ts
@@ -15,6 +15,14 @@ export type VoiceServiceState = "idle" | "listening" | "recording" | "thinking" 
 
 export type VoiceStateCb = (state: VoiceServiceState) => void;
 
+/**
+ * Live recording transcript callback: receives the accumulated transcript so
+ * far (segments joined with "\n", in speech order) each time a recording
+ * segment's STT resolves with text, and "" when the recording state is reset
+ * so a new recording starts with a clean draft.
+ */
+export type RecordingTranscriptCb = (text: string) => void;
+
 export interface VoiceError {
   /** Coarse category so the UI can branch (permission/network/etc). */
   kind: "permission" | "network" | "vad" | "stt" | "tts" | "playback" | "timeout" | "unknown";
@@ -166,6 +174,14 @@ export interface IAudioService {
 
   /** True while a listen() is pinned open in recording mode. */
   isRecording(): boolean;
+
+  /**
+   * Subscribe to the live recording transcript: while a recording is active,
+   * fires with the accumulated text so far each time a segment's STT resolves
+   * (newline-joined, speech order — same join stopRecording() uses), and with
+   * "" when recording state resets. Returns an unsubscribe fn.
+   */
+  onRecordingTranscript(cb: RecordingTranscriptCb): () => void;
 
   /** Synthesize + play `text`; resolve on playback end. */
   speak(text: string): Promise<void>;

--- a/frontend/src/voice/types.ts
+++ b/frontend/src/voice/types.ts
@@ -6,8 +6,12 @@
 // pure-TS service with no React/DOM-component dependency so it can be driven
 // from a dev harness, Playwright, and later from VoicePane.tsx.
 
-/** The four orb-visible states. `thinking` = VAD ended, STT/agent in flight. */
-export type VoiceServiceState = "idle" | "listening" | "thinking" | "speaking";
+/**
+ * The orb-visible states. `thinking` = VAD ended, STT/agent in flight.
+ * `recording` = a listen turn the user pinned open: VAD segments are
+ * transcribed as they end but the turn only resolves on an explicit stop.
+ */
+export type VoiceServiceState = "idle" | "listening" | "recording" | "thinking" | "speaking";
 
 export type VoiceStateCb = (state: VoiceServiceState) => void;
 
@@ -142,6 +146,26 @@ export interface IAudioService {
 
   /** Cancel an in-flight listen() (rejects its promise with a cancel error). */
   cancelListen(): void;
+
+  /**
+   * Pin the active listen() open as a long-form recording: VAD endpointing no
+   * longer resolves the turn — each detected segment is transcribed immediately
+   * and accumulated, and the per-listen maxListenMs timeout is disarmed (a
+   * generous recording safety ceiling applies instead). No-op unless a listen()
+   * is in flight and not already recording.
+   */
+  startRecording(): void;
+
+  /**
+   * Finalize a recording: flush any mid-speech segment, await the in-flight
+   * segment transcriptions in order, and resolve the pending listen() with the
+   * joined transcript. If nothing was captured, behaves like the existing
+   * no-speech (timeout) path. No-op if not recording.
+   */
+  stopRecording(): Promise<void>;
+
+  /** True while a listen() is pinned open in recording mode. */
+  isRecording(): boolean;
 
   /** Synthesize + play `text`; resolve on playback end. */
   speak(text: string): Promise<void>;

--- a/frontend/src/voice/voiceBridge.ts
+++ b/frontend/src/voice/voiceBridge.ts
@@ -16,6 +16,11 @@
 import * as api from "../api";
 import type { IAudioService } from "./types";
 
+// While the user holds a listen open in recording mode, ping the Go bridge so
+// it resets the request's ListenTimeout (120s) timer. 30s leaves a wide margin
+// even if a ping or two is lost.
+const RECORDING_EXTEND_INTERVAL_MS = 30_000;
+
 /** Payload of the "voice:request" event emitted by the Go voice bridge. */
 export interface VoiceRequest {
   sessionId: string;
@@ -77,8 +82,38 @@ export function registerVoiceBridge(
     void handleRequest(req, service, callbacks, inFlight);
   });
 
+  // Recording keepalive: while the service reports "recording", periodically
+  // extend the in-flight listen request's Go-side timeout so a long recording
+  // isn't cut off by ListenTimeout. Driven off the service state so it works
+  // identically in the native webview and remote browser clients (the api call
+  // goes through the same callGo transport as voiceResult).
+  let extendTimer: ReturnType<typeof setInterval> | null = null;
+  const stopExtend = () => {
+    if (extendTimer) {
+      clearInterval(extendTimer);
+      extendTimer = null;
+    }
+  };
+  const offRecordingState = service.onState((s) => {
+    if (s === "recording") {
+      if (extendTimer) return;
+      const ping = () => {
+        const id = inFlight.requestId;
+        if (id) void api.voiceListenExtend(id).catch(() => {});
+      };
+      // Extend immediately (the listen may already be near its deadline), then
+      // on the interval.
+      ping();
+      extendTimer = setInterval(ping, RECORDING_EXTEND_INTERVAL_MS);
+    } else {
+      stopExtend();
+    }
+  });
+
   return () => {
     if (cancel) cancel();
+    stopExtend();
+    offRecordingState();
     // If a request is still unsettled at tear-down, tell Go the voice ended so
     // the waiting tool returns immediately (graceful, not an error). Clear the
     // marker first so we fire exactly once.

--- a/frontend/src/voice/voiceBridge.ts
+++ b/frontend/src/voice/voiceBridge.ts
@@ -27,6 +27,12 @@ export interface VoiceRequest {
   requestId: string;
   kind: "listen" | "speak";
   text: string;
+  /**
+   * For kind "listen": start the turn already pinned open in recording mode
+   * (agent-activated long-form dictation; voice_listen/voice_converse with
+   * record=true). Absent/false → a normal single-utterance listen.
+   */
+  record?: boolean;
 }
 
 /**
@@ -157,7 +163,7 @@ async function handleRequest(
   };
   try {
     if (req.kind === "listen") {
-      const transcript = await service.listen();
+      const transcript = await service.listen(req.record ? { record: true } : undefined);
       settle();
       safeCb(callbacks.onUserTranscript, transcript);
       await api.voiceResult(req.requestId, transcript, "");

--- a/frontend/tests/voice/audioService.spec.ts
+++ b/frontend/tests/voice/audioService.spec.ts
@@ -87,6 +87,54 @@ test("listen(): fake-audio WAV drives the real Silero VAD to endpoint → STT ma
   ).toBeFalsy();
 });
 
+test("listen({record:true}) starts pinned in recording mode; a segment ending in 'stop recording' finalizes hands-free with the phrase stripped", async ({
+  page,
+}) => {
+  await installStateRecorder(page);
+
+  await page.evaluate(() => {
+    const w = window as unknown as {
+      __voiceService: { listen: (o?: { record?: boolean }) => Promise<string> };
+      __voiceTranscriptQueue?: string[];
+      __recordedResult?: string;
+    };
+    // Script the segment's STT result to END with the spoken stop phrase.
+    w.__voiceTranscriptQueue = ["I want dark mode and bigger fonts. Stop recording."];
+    w.__recordedResult = undefined;
+    void w.__voiceService.listen({ record: true }).then(
+      (t) => (w.__recordedResult = t),
+      (e) => (w.__recordedResult = `ERROR:${String((e as { message?: string })?.message ?? e)}`),
+    );
+  });
+
+  // Agent-activated recording: the turn is pinned open the moment it is armed,
+  // BEFORE any speech — state goes straight to "recording".
+  await page.waitForFunction(
+    () => (window as unknown as { __voiceState?: string }).__voiceState === "recording",
+  );
+
+  // The fake-audio utterance endpoints → the segment's STT resolves ending in
+  // the stop phrase → the recording finalizes as if "■ stop" was pressed, with
+  // the phrase (and separating punctuation) stripped from the transcript.
+  await page.waitForFunction(
+    () =>
+      (window as unknown as { __recordedResult?: string }).__recordedResult !== undefined,
+  );
+  const result = await page.evaluate(
+    () => (window as unknown as { __recordedResult?: string }).__recordedResult,
+  );
+  expect(result).toBe("I want dark mode and bigger fonts");
+
+  // The turn never passed through the plain "listening" state: record mode
+  // enters "recording" directly (and speech-start keeps it there).
+  const log = await getStateLog(page);
+  expect(log).toContain("recording");
+  expect(log).not.toContain("listening");
+  // After the hands-free stop, the turn resolves into the post-listen
+  // "thinking" hold (same as a manual stop).
+  expect(log[log.length - 1]).toBe("thinking");
+});
+
 test("speak(): TTS → <audio> emits play then ended, state speaking → idle", async ({
   page,
 }) => {

--- a/frontend/wailsjs/go/controller/configController.d.ts
+++ b/frontend/wailsjs/go/controller/configController.d.ts
@@ -25,6 +25,5 @@ export function SaveQuantiFile(arg1:string,arg2:string):Promise<void>;
 
 export function SendNotification(arg1:string,arg2:string):Promise<void>;
 
-export function SetMindmapPaneOpen(arg1:boolean):Promise<void>;
 
 export function SetVoicePaneOpen(arg1:boolean):Promise<void>;

--- a/frontend/wailsjs/go/controller/configController.js
+++ b/frontend/wailsjs/go/controller/configController.js
@@ -46,10 +46,6 @@ export function SendNotification(arg1, arg2) {
   return window['go']['controller']['configController']['SendNotification'](arg1, arg2);
 }
 
-export function SetMindmapPaneOpen(arg1) {
-  return window['go']['controller']['configController']['SetMindmapPaneOpen'](arg1);
-}
-
 export function SetVoicePaneOpen(arg1) {
   return window['go']['controller']['configController']['SetVoicePaneOpen'](arg1);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -127,7 +127,6 @@ export namespace dto {
 	    idleTimeoutMinutes: number;
 	    activeSessionId: string;
 	    openSessionIds: string[];
-	    mindmapPaneOpen: boolean;
 	    voicePaneOpen: boolean;
 	    dataDirectory: string;
 	    worktreeDirectory: string;
@@ -176,7 +175,6 @@ export namespace dto {
 	        this.idleTimeoutMinutes = source["idleTimeoutMinutes"];
 	        this.activeSessionId = source["activeSessionId"];
 	        this.openSessionIds = source["openSessionIds"];
-	        this.mindmapPaneOpen = source["mindmapPaneOpen"];
 	        this.voicePaneOpen = source["voicePaneOpen"];
 	        this.dataDirectory = source["dataDirectory"];
 	        this.worktreeDirectory = source["worktreeDirectory"];
@@ -749,7 +747,6 @@ export namespace dto {
 	    idleTimeoutMinutes: number;
 	    activeSessionId: string;
 	    openSessionIds: string[];
-	    mindmapPaneOpen: boolean;
 	    voicePaneOpen: boolean;
 	    dataDirectory: string;
 	    worktreeDirectory: string;
@@ -797,7 +794,6 @@ export namespace dto {
 	        this.idleTimeoutMinutes = source["idleTimeoutMinutes"];
 	        this.activeSessionId = source["activeSessionId"];
 	        this.openSessionIds = source["openSessionIds"];
-	        this.mindmapPaneOpen = source["mindmapPaneOpen"];
 	        this.voicePaneOpen = source["voicePaneOpen"];
 	        this.dataDirectory = source["dataDirectory"];
 	        this.worktreeDirectory = source["worktreeDirectory"];

--- a/internal/domain/entity/config.go
+++ b/internal/domain/entity/config.go
@@ -99,7 +99,6 @@ type Config struct {
 	IdleTimeoutMinutes    int      `json:"idleTimeoutMinutes"`
 	ActiveSessionID       string   `json:"activeSessionId"`
 	OpenSessionIDs        []string `json:"openSessionIds"`
-	MindmapPaneOpen       bool     `json:"mindmapPaneOpen"`
 	VoicePaneOpen         bool     `json:"voicePaneOpen"`
 
 	// Storage & Data

--- a/internal/integration/adapter/config_controller.go
+++ b/internal/integration/adapter/config_controller.go
@@ -13,7 +13,6 @@ type ConfigController interface {
 	OnShutdown(ctx context.Context)
 	GetConfig() (*dto.ConfigResponse, error)
 	SaveConfig(request dto.SaveConfigRequest) error
-	SetMindmapPaneOpen(open bool) error
 	SetVoicePaneOpen(open bool) error
 	ResetDatabase() error
 	ClearSessionLogs() error

--- a/internal/integration/entrypoint/controller/config.go
+++ b/internal/integration/entrypoint/controller/config.go
@@ -68,26 +68,6 @@ func (c *configController) SaveConfig(request dto.SaveConfigRequest) error {
 	return c.configManager.SaveConfig(&cfg)
 }
 
-// SetMindmapPaneOpen persists the global mindmap pane open/close flag and broadcasts
-// the change to all clients via the "mindmap:pane" event so they stay in sync.
-func (c *configController) SetMindmapPaneOpen(open bool) error {
-	cfg, err := c.configManager.GetConfig()
-	if err != nil {
-		return err
-	}
-
-	cfg.MindmapPaneOpen = open
-	if err := c.configManager.SaveConfig(cfg); err != nil {
-		return err
-	}
-
-	if c.emitter != nil {
-		c.emitter.Emit("mindmap:pane", map[string]any{"open": open})
-	}
-
-	return nil
-}
-
 // SetVoicePaneOpen persists the global voice pane open/close flag and broadcasts
 // the change to all clients via the "voice:pane" event so they stay in sync.
 func (c *configController) SetVoicePaneOpen(open bool) error {

--- a/internal/integration/entrypoint/dto/config.go
+++ b/internal/integration/entrypoint/dto/config.go
@@ -56,7 +56,6 @@ type SaveConfigRequest struct {
 	IdleTimeoutMinutes    int      `json:"idleTimeoutMinutes"`
 	ActiveSessionID       string   `json:"activeSessionId"`
 	OpenSessionIDs        []string `json:"openSessionIds"`
-	MindmapPaneOpen       bool     `json:"mindmapPaneOpen"`
 	VoicePaneOpen         bool     `json:"voicePaneOpen"`
 
 	// Storage & Data
@@ -116,7 +115,6 @@ type ConfigResponse struct {
 	IdleTimeoutMinutes    int      `json:"idleTimeoutMinutes"`
 	ActiveSessionID       string   `json:"activeSessionId"`
 	OpenSessionIDs        []string `json:"openSessionIds"`
-	MindmapPaneOpen       bool     `json:"mindmapPaneOpen"`
 	VoicePaneOpen         bool     `json:"voicePaneOpen"`
 
 	// Storage & Data
@@ -179,7 +177,6 @@ func ConfigResponseFromEntity(cfg entity.Config) ConfigResponse {
 		IdleTimeoutMinutes:    cfg.IdleTimeoutMinutes,
 		ActiveSessionID:       cfg.ActiveSessionID,
 		OpenSessionIDs:        cfg.OpenSessionIDs,
-		MindmapPaneOpen:       cfg.MindmapPaneOpen,
 		VoicePaneOpen:         cfg.VoicePaneOpen,
 		DataDirectory:         cfg.DataDirectory,
 		WorktreeDirectory:     cfg.WorktreeDirectory,
@@ -270,7 +267,6 @@ func (r SaveConfigRequest) ToEntity() entity.Config {
 		IdleTimeoutMinutes:    r.IdleTimeoutMinutes,
 		ActiveSessionID:       r.ActiveSessionID,
 		OpenSessionIDs:        r.OpenSessionIDs,
-		MindmapPaneOpen:       r.MindmapPaneOpen,
 		VoicePaneOpen:         r.VoicePaneOpen,
 		DataDirectory:         r.DataDirectory,
 		WorktreeDirectory:     r.WorktreeDirectory,

--- a/internal/integration/mcp/server.go
+++ b/internal/integration/mcp/server.go
@@ -757,6 +757,7 @@ Returns the created session object with generated ID. The session starts in 'idl
 			mcp.WithDescription(`Listen to the user and return what they said as text.
 
 Captures one spoken utterance from the user (mic capture + voice-activity detection + speech-to-text run in the voice pane) and returns the transcript. Use this in a voice conversation to hear the user's reply. Blocks until the user finishes speaking or the listen times out. If it times out (no voice pane open, or the user said nothing), an error is returned — you can retry.`),
+			mcp.WithBoolean("record", mcp.Description("Set record=true when the user announced they want to give a long answer / dictate — it pins the microphone open across pauses until the user stops (taps stop or says 'stop recording'). Default: false (normal single-utterance listen).")),
 		),
 		s.handleVoiceListen,
 	)
@@ -773,6 +774,7 @@ Captures one spoken utterance from the user (mic capture + voice-activity detect
 		mcp.NewTool("voice_converse",
 			mcp.WithDescription(`Speak the given text aloud, then immediately listen for the user's reply — one combined turn. Returns the user's transcript. This is sugar for voice_speak(text) followed by voice_listen(); use it to keep a back-and-forth conversation flowing in a single call.`),
 			mcp.WithString("text", mcp.Required(), mcp.Description("The text to speak before listening. Plain, conversational, speech-friendly.")),
+			mcp.WithBoolean("record", mcp.Description("Set record=true when the user announced they want to give a long answer / dictate — after speaking, the listen pins the microphone open across pauses until the user stops (taps stop or says 'stop recording'). Default: false.")),
 		),
 		s.handleVoiceConverse,
 	)
@@ -2362,7 +2364,7 @@ func voiceEndedResult() *mcp.CallToolResult {
 	return mcp.NewToolResultText("The voice pane is no longer responding (it was closed, or this session is no longer the active voice session). Voice mode has ENDED. Stop calling voice tools (voice_listen/voice_speak/voice_converse) and resume normal text interaction. Do not retry voice unless the user asks.")
 }
 
-func (s *QuantMCPServer) handleVoiceListen(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (s *QuantMCPServer) handleVoiceListen(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	if s.voiceBridge == nil {
 		return mcp.NewToolResultError("voice bridge not available"), nil
 	}
@@ -2370,8 +2372,9 @@ func (s *QuantMCPServer) handleVoiceListen(ctx context.Context, _ mcp.CallToolRe
 	if sessionID == "" {
 		return mcp.NewToolResultError("voice_listen requires a session context (X-Quant-Session) — call it from a hosted session"), nil
 	}
+	record := boolArg(request.GetArguments(), "record")
 
-	reply, err := s.voiceBridge.Request(ctx, sessionID, "listen", "", voice.ListenTimeout)
+	reply, err := s.voiceBridge.Request(ctx, sessionID, "listen", "", record, voice.ListenTimeout)
 	if err != nil {
 		if errors.Is(err, voice.ErrVoiceEnded) {
 			return voiceEndedResult(), nil
@@ -2394,7 +2397,7 @@ func (s *QuantMCPServer) handleVoiceSpeak(ctx context.Context, request mcp.CallT
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	if _, err := s.voiceBridge.Request(ctx, sessionID, "speak", text, voice.SpeakTimeout); err != nil {
+	if _, err := s.voiceBridge.Request(ctx, sessionID, "speak", text, false, voice.SpeakTimeout); err != nil {
 		if errors.Is(err, voice.ErrVoiceEnded) {
 			return voiceEndedResult(), nil
 		}
@@ -2415,15 +2418,16 @@ func (s *QuantMCPServer) handleVoiceConverse(ctx context.Context, request mcp.Ca
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	record := boolArg(request.GetArguments(), "record")
 
 	// Speak first, then listen for the reply — one combined turn.
-	if _, err := s.voiceBridge.Request(ctx, sessionID, "speak", text, voice.SpeakTimeout); err != nil {
+	if _, err := s.voiceBridge.Request(ctx, sessionID, "speak", text, false, voice.SpeakTimeout); err != nil {
 		if errors.Is(err, voice.ErrVoiceEnded) {
 			return voiceEndedResult(), nil
 		}
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-	reply, err := s.voiceBridge.Request(ctx, sessionID, "listen", "", voice.ListenTimeout)
+	reply, err := s.voiceBridge.Request(ctx, sessionID, "listen", "", record, voice.ListenTimeout)
 	if err != nil {
 		if errors.Is(err, voice.ErrVoiceEnded) {
 			return voiceEndedResult(), nil

--- a/internal/integration/process/manager.go
+++ b/internal/integration/process/manager.go
@@ -55,6 +55,30 @@ func personaArgs() []string {
 	return []string{"--append-system-prompt", "$QUANT_BASE_PERSONA"}
 }
 
+// defaultMCPToolTimeoutMS is the MCP_TOOL_TIMEOUT value (milliseconds) injected
+// into every claude session quant spawns. The claude CLI's MCP client aborts any
+// tool call on HTTP-transport MCP servers after a hardcoded 60s default ("The
+// operation timed out."), which would kill voice_listen/voice_converse mid
+// recording: recording mode legitimately blocks up to the 15-min RECORDING_MAX_MS
+// ceiling (frontend/src/voice/audioService.ts), plus STT time and a speak leg.
+// Quant's own 120s ListenTimeout is already kept alive Go-side (Bridge.Extend),
+// but only MCP_TOOL_TIMEOUT raises the client-side limit — verified empirically
+// 2026-06-09: a 90s-blocking HTTP MCP tool fails at 60s by default and succeeds
+// with MCP_TOOL_TIMEOUT set. 20 minutes comfortably exceeds the worst case.
+const defaultMCPToolTimeoutMS = "1200000"
+
+// withMCPToolTimeout appends MCP_TOOL_TIMEOUT=defaultMCPToolTimeoutMS to env
+// unless the variable is already present (e.g. exported by the user's login
+// shell, which shellEnv() inherits), so an explicit user value always wins.
+func withMCPToolTimeout(env []string) []string {
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "MCP_TOOL_TIMEOUT=") {
+			return env
+		}
+	}
+	return append(env, "MCP_TOOL_TIMEOUT="+defaultMCPToolTimeoutMS)
+}
+
 // claudeProcess holds the running process and its PTY master.
 type claudeProcess struct {
 	cmd *exec.Cmd
@@ -298,6 +322,10 @@ func (m *processManager) Spawn(sessionID string, sessionType string, directory s
 	if os.Getenv("QUANT_SKIP_PERSONA") != "1" {
 		baseEnv = append(baseEnv, "QUANT_BASE_PERSONA="+m.resolvePersona())
 	}
+	// Raise claude's client-side MCP tool-call timeout so long voice recordings
+	// survive past the hardcoded 60s HTTP-MCP default (see defaultMCPToolTimeoutMS).
+	// Skipped when the user already exports MCP_TOOL_TIMEOUT themselves.
+	baseEnv = withMCPToolTimeout(baseEnv)
 	cmd.Env = baseEnv
 
 	ptm, err := pty.Start(cmd)

--- a/internal/integration/process/manager_test.go
+++ b/internal/integration/process/manager_test.go
@@ -60,6 +60,37 @@ func TestPersonaArgs(t *testing.T) {
 	})
 }
 
+func TestWithMCPToolTimeout(t *testing.T) {
+	t.Run("default applied when absent", func(t *testing.T) {
+		env := []string{"PATH=/usr/bin", "QUANT_SESSION_ID=abc"}
+		got := withMCPToolTimeout(env)
+		want := "MCP_TOOL_TIMEOUT=" + defaultMCPToolTimeoutMS
+		if len(got) != len(env)+1 || got[len(got)-1] != want {
+			t.Fatalf("withMCPToolTimeout(%v) = %v, want %q appended", env, got, want)
+		}
+	})
+
+	t.Run("user-provided value is not overridden", func(t *testing.T) {
+		env := []string{"PATH=/usr/bin", "MCP_TOOL_TIMEOUT=90000"}
+		got := withMCPToolTimeout(env)
+		if len(got) != len(env) {
+			t.Fatalf("withMCPToolTimeout(%v) = %v, want unchanged", env, got)
+		}
+		count := 0
+		for _, kv := range got {
+			if strings.HasPrefix(kv, "MCP_TOOL_TIMEOUT=") {
+				count++
+				if kv != "MCP_TOOL_TIMEOUT=90000" {
+					t.Fatalf("user value overridden: got %q", kv)
+				}
+			}
+		}
+		if count != 1 {
+			t.Fatalf("expected exactly one MCP_TOOL_TIMEOUT entry, got %d in %v", count, got)
+		}
+	})
+}
+
 func TestPersonaBaseContent(t *testing.T) {
 	if persona.Base == "" {
 		t.Fatal("persona.Base is empty")

--- a/internal/integration/voice/bridge.go
+++ b/internal/integration/voice/bridge.go
@@ -70,13 +70,23 @@ type VoiceRequestEvent struct {
 // ignored safely. Targeting a single "active/primary" client is left for later.
 type Bridge struct {
 	mu      sync.Mutex
-	pending map[string]chan VoiceReply
+	pending map[string]*pendingRequest
 	emit    Emitter
 	// appCtx is the Wails app LIFECYCLE context captured in OnStartup. Wails
 	// runtime.EventsEmit rejects any other context ("an invalid context was
 	// passed"), so the voice:request event MUST be emitted with this context —
 	// NOT the per-request MCP/HTTP context that flows into Request().
 	appCtx context.Context
+}
+
+// pendingRequest tracks one in-flight voice request: the reply channel the
+// blocked Request select waits on, plus a keepalive channel that resets the
+// request's timeout (used by recording mode, where a listen can legitimately
+// outlive ListenTimeout). Both channels are buffered (cap 1) so senders never
+// block.
+type pendingRequest struct {
+	ch     chan VoiceReply
+	extend chan struct{}
 }
 
 // SetContext stores the Wails app lifecycle context used for emitting events.
@@ -93,7 +103,7 @@ func (b *Bridge) SetContext(ctx context.Context) {
 // but production wiring should always supply remote.Emit.
 func NewBridge(emit Emitter) *Bridge {
 	return &Bridge{
-		pending: make(map[string]chan VoiceReply),
+		pending: make(map[string]*pendingRequest),
 		emit:    emit,
 	}
 }
@@ -130,10 +140,13 @@ func newRequestID() string {
 // recoverable error so the calling agent can retry.
 func (b *Bridge) Request(ctx context.Context, sessionID, kind, text string, timeout time.Duration) (VoiceReply, error) {
 	requestID := newRequestID()
-	ch := make(chan VoiceReply, 1)
+	p := &pendingRequest{
+		ch:     make(chan VoiceReply, 1),
+		extend: make(chan struct{}, 1),
+	}
 
 	b.mu.Lock()
-	b.pending[requestID] = ch
+	b.pending[requestID] = p
 	emit := b.emit
 	emitCtx := b.appCtx // Wails lifecycle ctx — NOT the request ctx
 	b.mu.Unlock()
@@ -147,28 +160,55 @@ func (b *Bridge) Request(ctx context.Context, sessionID, kind, text string, time
 		})
 	}
 
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for {
+		select {
+		case reply := <-p.ch:
+			// The channel is buffered and only written once, but delete the entry so
+			// the map does not grow unbounded.
+			b.remove(requestID)
+			if reply.Err != "" {
+				return reply, fmt.Errorf("voice %s failed: %s", kind, reply.Err)
+			}
+			if reply.Closed {
+				// The pane closed/moved mid-request: end voice mode gracefully rather
+				// than treating it as an error or waiting out the timeout.
+				return reply, fmt.Errorf("voice %s ended (pane closed): %w", kind, ErrVoiceEnded)
+			}
+			return reply, nil
+		case <-p.extend:
+			// Keepalive from the frontend (recording mode): push the deadline out
+			// by the full timeout again. Reset without draining is safe on Go 1.23+
+			// timer semantics (go.mod pins well above that).
+			timer.Reset(timeout)
+		case <-timer.C:
+			b.remove(requestID)
+			// No client responded within the timeout: the voice surface is gone. Wrap
+			// as ErrVoiceEnded so the agent stops calling voice tools instead of looping.
+			return VoiceReply{}, fmt.Errorf("voice %s ended (timed out after %s waiting for the pane): %w", kind, timeout, ErrVoiceEnded)
+		case <-ctx.Done():
+			b.remove(requestID)
+			return VoiceReply{}, fmt.Errorf("voice %s cancelled: %w", kind, ctx.Err())
+		}
+	}
+}
+
+// Extend resets the timeout of the in-flight request with the given requestId
+// (keepalive). The frontend pings this every ~30s while the user is in recording
+// mode so a long-form listen doesn't hit ListenTimeout mid-recording. Unknown or
+// already-settled requestIds are ignored; the send is non-blocking (buffered,
+// and a pending-but-unconsumed extend is equivalent).
+func (b *Bridge) Extend(requestID string) {
+	b.mu.Lock()
+	p, ok := b.pending[requestID]
+	b.mu.Unlock()
+	if !ok {
+		return
+	}
 	select {
-	case reply := <-ch:
-		// The channel is buffered and only written once, but delete the entry so
-		// the map does not grow unbounded.
-		b.remove(requestID)
-		if reply.Err != "" {
-			return reply, fmt.Errorf("voice %s failed: %s", kind, reply.Err)
-		}
-		if reply.Closed {
-			// The pane closed/moved mid-request: end voice mode gracefully rather
-			// than treating it as an error or waiting out the timeout.
-			return reply, fmt.Errorf("voice %s ended (pane closed): %w", kind, ErrVoiceEnded)
-		}
-		return reply, nil
-	case <-time.After(timeout):
-		b.remove(requestID)
-		// No client responded within the timeout: the voice surface is gone. Wrap
-		// as ErrVoiceEnded so the agent stops calling voice tools instead of looping.
-		return VoiceReply{}, fmt.Errorf("voice %s ended (timed out after %s waiting for the pane): %w", kind, timeout, ErrVoiceEnded)
-	case <-ctx.Done():
-		b.remove(requestID)
-		return VoiceReply{}, fmt.Errorf("voice %s cancelled: %w", kind, ctx.Err())
+	case p.extend <- struct{}{}:
+	default:
 	}
 }
 
@@ -178,7 +218,7 @@ func (b *Bridge) Request(ctx context.Context, sessionID, kind, text string, time
 // buffered channel, and the entry is removed so a duplicate Resolve is a no-op.
 func (b *Bridge) Resolve(requestID string, reply VoiceReply) {
 	b.mu.Lock()
-	ch, ok := b.pending[requestID]
+	p, ok := b.pending[requestID]
 	if ok {
 		delete(b.pending, requestID)
 	}
@@ -187,11 +227,11 @@ func (b *Bridge) Resolve(requestID string, reply VoiceReply) {
 	if !ok {
 		return
 	}
-	// Non-blocking send: ch is buffered (cap 1) and unique to this request, so
-	// this never blocks. The select's default guards against the impossible
-	// double-send.
+	// Non-blocking send: the channel is buffered (cap 1) and unique to this
+	// request, so this never blocks. The select's default guards against the
+	// impossible double-send.
 	select {
-	case ch <- reply:
+	case p.ch <- reply:
 	default:
 	}
 }

--- a/internal/integration/voice/bridge.go
+++ b/internal/integration/voice/bridge.go
@@ -56,6 +56,10 @@ type VoiceRequestEvent struct {
 	RequestID string `json:"requestId"`
 	Kind      string `json:"kind"` // "listen" | "speak"
 	Text      string `json:"text"` // text to speak (empty for listen)
+	// Record asks the frontend to start a "listen" already pinned open in
+	// recording mode (long-form dictation across pauses, ended only by the user's
+	// explicit stop or the spoken stop phrase). Ignored for "speak".
+	Record bool `json:"record"`
 }
 
 // Bridge is the request→do-audio→reply registry that connects the Go-side MCP
@@ -132,13 +136,14 @@ func newRequestID() string {
 // resolves it, the timeout elapses, or ctx is cancelled.
 //
 //   - kind "listen": text is ignored; the returned VoiceReply.Transcript holds
-//     the recognized speech.
+//     the recognized speech. record=true starts the listen already pinned open
+//     in recording mode (long-form dictation across pauses).
 //   - kind "speak":  text is the phrase to synthesize; the reply's Done is true
-//     once playback finishes.
+//     once playback finishes. record is ignored.
 //
 // On timeout or cancellation it cleans up the pending entry and returns a clear,
 // recoverable error so the calling agent can retry.
-func (b *Bridge) Request(ctx context.Context, sessionID, kind, text string, timeout time.Duration) (VoiceReply, error) {
+func (b *Bridge) Request(ctx context.Context, sessionID, kind, text string, record bool, timeout time.Duration) (VoiceReply, error) {
 	requestID := newRequestID()
 	p := &pendingRequest{
 		ch:     make(chan VoiceReply, 1),
@@ -157,6 +162,7 @@ func (b *Bridge) Request(ctx context.Context, sessionID, kind, text string, time
 			RequestID: requestID,
 			Kind:      kind,
 			Text:      text,
+			Record:    record,
 		})
 	}
 

--- a/internal/integration/voice/bridge_test.go
+++ b/internal/integration/voice/bridge_test.go
@@ -123,6 +123,98 @@ func TestBridgeClosedResolve(t *testing.T) {
 	}
 }
 
+// TestBridgeExtendResetsTimeout verifies the recording-mode keepalive: Extend
+// pushes the request's deadline out by the full timeout again, so repeated
+// extends keep a request alive well past its original timeout, and the request
+// still resolves normally afterwards.
+func TestBridgeExtendResetsTimeout(t *testing.T) {
+	var capturedReqID string
+	var mu sync.Mutex
+	b := NewBridge(func(_ context.Context, _ string, data interface{}) {
+		ev := data.(VoiceRequestEvent)
+		mu.Lock()
+		capturedReqID = ev.RequestID
+		mu.Unlock()
+	})
+
+	type result struct {
+		reply VoiceReply
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		reply, err := b.Request(context.Background(), "sess-1", "listen", "", 150*time.Millisecond)
+		done <- result{reply, err}
+	}()
+
+	reqID := waitForReqID(t, &mu, &capturedReqID)
+	// Extend every 80ms — total wait (4×80ms = 320ms) far exceeds the original
+	// 150ms timeout, so the request only survives if Extend resets the timer.
+	for i := 0; i < 4; i++ {
+		b.Extend(reqID)
+		time.Sleep(80 * time.Millisecond)
+		select {
+		case r := <-done:
+			t.Fatalf("request ended early despite extends (iteration %d): reply=%+v err=%v", i, r.reply, r.err)
+		default:
+		}
+	}
+
+	b.Resolve(reqID, VoiceReply{Transcript: "a long recorded speech"})
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("Request returned error after extends: %v", r.err)
+		}
+		if r.reply.Transcript != "a long recorded speech" {
+			t.Fatalf("transcript = %q, want %q", r.reply.Transcript, "a long recorded speech")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Request did not unblock after Resolve")
+	}
+
+	// Extending an unknown/settled requestId must be a safe no-op.
+	b.Extend("does-not-exist")
+	b.Extend(reqID)
+}
+
+// TestBridgeExtendDoesNotOutliveResolveTimeout verifies a request that stops
+// being extended still times out (the keepalive doesn't make it immortal).
+func TestBridgeExtendDoesNotOutliveResolveTimeout(t *testing.T) {
+	var capturedReqID string
+	var mu sync.Mutex
+	b := NewBridge(func(_ context.Context, _ string, data interface{}) {
+		ev := data.(VoiceRequestEvent)
+		mu.Lock()
+		capturedReqID = ev.RequestID
+		mu.Unlock()
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := b.Request(context.Background(), "sess-1", "listen", "", 60*time.Millisecond)
+		done <- err
+	}()
+
+	reqID := waitForReqID(t, &mu, &capturedReqID)
+	b.Extend(reqID)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrVoiceEnded) {
+			t.Fatalf("expected ErrVoiceEnded after extends stop, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Request never timed out after extends stopped")
+	}
+	b.mu.Lock()
+	n := len(b.pending)
+	b.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("pending map not cleaned up after timeout: %d entries", n)
+	}
+}
+
 // TestBridgeCtxCancel verifies cancellation returns an error and cleans up.
 func TestBridgeCtxCancel(t *testing.T) {
 	b := NewBridge(func(_ context.Context, _ string, _ interface{}) {})

--- a/internal/integration/voice/bridge_test.go
+++ b/internal/integration/voice/bridge_test.go
@@ -33,7 +33,7 @@ func TestBridgeRequestResolves(t *testing.T) {
 	}
 	done := make(chan result, 1)
 	go func() {
-		reply, err := b.Request(context.Background(), "sess-1", "listen", "", time.Second)
+		reply, err := b.Request(context.Background(), "sess-1", "listen", "", false, time.Second)
 		done <- result{reply, err}
 	}()
 
@@ -61,7 +61,7 @@ func TestBridgeTimeout(t *testing.T) {
 	b := NewBridge(func(_ context.Context, _ string, _ interface{}) {})
 
 	start := time.Now()
-	_, err := b.Request(context.Background(), "sess-1", "listen", "", 50*time.Millisecond)
+	_, err := b.Request(context.Background(), "sess-1", "listen", "", false, 50*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected a timeout error, got nil")
 	}
@@ -100,7 +100,7 @@ func TestBridgeClosedResolve(t *testing.T) {
 	done := make(chan result, 1)
 	go func() {
 		// A generous timeout: the Closed resolve must end the request well before it.
-		reply, err := b.Request(context.Background(), "sess-1", "listen", "", time.Minute)
+		reply, err := b.Request(context.Background(), "sess-1", "listen", "", false, time.Minute)
 		done <- result{reply, err}
 	}()
 
@@ -143,7 +143,7 @@ func TestBridgeExtendResetsTimeout(t *testing.T) {
 	}
 	done := make(chan result, 1)
 	go func() {
-		reply, err := b.Request(context.Background(), "sess-1", "listen", "", 150*time.Millisecond)
+		reply, err := b.Request(context.Background(), "sess-1", "listen", "", false, 150*time.Millisecond)
 		done <- result{reply, err}
 	}()
 
@@ -192,7 +192,7 @@ func TestBridgeExtendDoesNotOutliveResolveTimeout(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := b.Request(context.Background(), "sess-1", "listen", "", 60*time.Millisecond)
+		_, err := b.Request(context.Background(), "sess-1", "listen", "", false, 60*time.Millisecond)
 		done <- err
 	}()
 
@@ -222,7 +222,7 @@ func TestBridgeCtxCancel(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := b.Request(ctx, "sess-1", "speak", "hi", time.Minute)
+		_, err := b.Request(ctx, "sess-1", "speak", "hi", false, time.Minute)
 		done <- err
 	}()
 
@@ -254,7 +254,7 @@ func TestBridgeUnknownAndDuplicateResolve(t *testing.T) {
 
 	done := make(chan VoiceReply, 1)
 	go func() {
-		reply, _ := b.Request(context.Background(), "sess-1", "listen", "", time.Second)
+		reply, _ := b.Request(context.Background(), "sess-1", "listen", "", false, time.Second)
 		done <- reply
 	}()
 
@@ -294,7 +294,7 @@ func TestBridgeConcurrentNoCrossWires(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			reply, err := b.Request(context.Background(), sid, "listen", "", 2*time.Second)
+			reply, err := b.Request(context.Background(), sid, "listen", "", false, 2*time.Second)
 			if err != nil {
 				t.Errorf("session %s: %v", sid, err)
 				return
@@ -333,6 +333,47 @@ func TestBridgeConcurrentNoCrossWires(t *testing.T) {
 	}
 	if res["B"] != "reply-B" {
 		t.Fatalf("session B got %q, want reply-B (cross-wired?)", res["B"])
+	}
+}
+
+// TestBridgeRecordFlagRoundTrips verifies the record flag passed to Request is
+// carried on the emitted VoiceRequestEvent (true and false), so the frontend
+// can start a listen already pinned open in recording mode.
+func TestBridgeRecordFlagRoundTrips(t *testing.T) {
+	for _, record := range []bool{true, false} {
+		var capturedReqID string
+		var capturedRecord bool
+		var mu sync.Mutex
+		b := NewBridge(func(_ context.Context, _ string, data interface{}) {
+			ev := data.(VoiceRequestEvent)
+			mu.Lock()
+			capturedReqID = ev.RequestID
+			capturedRecord = ev.Record
+			mu.Unlock()
+		})
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := b.Request(context.Background(), "sess-1", "listen", "", record, time.Second)
+			done <- err
+		}()
+
+		reqID := waitForReqID(t, &mu, &capturedReqID)
+		mu.Lock()
+		got := capturedRecord
+		mu.Unlock()
+		if got != record {
+			t.Fatalf("emitted VoiceRequestEvent.Record = %v, want %v", got, record)
+		}
+		b.Resolve(reqID, VoiceReply{Transcript: "ok"})
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("Request returned error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Request did not unblock after Resolve")
+		}
 	}
 }
 

--- a/internal/integration/voice/voice.go
+++ b/internal/integration/voice/voice.go
@@ -153,6 +153,22 @@ func (c *voiceController) VoiceResultClosed(requestID string) error {
 	return nil
 }
 
+// VoiceListenExtend is the frontend keepalive for a long-running listen: while
+// the user holds the pane in recording mode the frontend pings this (every ~30s)
+// with the in-flight requestId, and the bridge resets that request's timeout so
+// a long-form recording isn't cut off by ListenTimeout. Unknown/settled
+// requestIds are ignored safely; non-recording listens never call this, so their
+// behavior is unchanged.
+//
+// It returns a single error (nil) to satisfy the remote-transport contract.
+func (c *voiceController) VoiceListenExtend(requestId string) error {
+	if c.bridge == nil {
+		return fmt.Errorf("voice bridge not initialized")
+	}
+	c.bridge.Extend(requestId)
+	return nil
+}
+
 // StartVoiceSession kicks a running session into the voice conversation loop by
 // injecting the VoicePersona message and auto-submitting it (Enter delivered as a
 // separate keystroke, mirroring the MCP send_message primitive so the Claude CLI

--- a/internal/integration/voice/voice.go
+++ b/internal/integration/voice/voice.go
@@ -72,6 +72,9 @@ const VoicePersona = "You are now in VOICE MODE — you and the user are having 
 	"if something is long or visual, summarize it in a sentence and offer to put the details in the terminal. " +
 	"You can still use all your normal tools to get real work done; when you do, narrate it in a few words instead of going silent. " +
 	"If you didn't catch what the user said, just ask them to repeat. " +
+	"If the user says they're about to give a long answer or asks to start recording, reply briefly — for example \"Recording — go ahead, say 'stop recording' when done.\" — " +
+	"via voice_converse with record=true (or voice_speak then voice_listen with record=true); " +
+	"the recording keeps the mic open across pauses and ends when the user says \"stop recording\" or taps stop. " +
 	"Start now: greet the user briefly with voice_converse, then keep the conversation going — " +
 	"after each user turn, think, then reply with voice_converse (or voice_speak if you don't expect a reply). " +
 	"Continue until the user says goodbye or the voice pane is closed."


### PR DESCRIPTION
## Summary
Adds a **recording mode** to local voice so the user can deliver long, multi-pause speeches without the ~3s silence detector cutting them off. Recording can be started by the user (button) or by the agent (tool flag), shows a live transcript as you speak, and can be stopped by button or by saying "stop recording".

Validated end-to-end by the user in an isolated `wails dev` instance.

## What's included (4 commits)

**1. Recording mode core (`5888375`)**
- `● rec` button in the VoicePane status bar while the orb is "listening" → pins the turn open with a new red `recording` orb state and a `■ stop mm:ss` elapsed indicator.
- VAD keeps running across pauses; each endpointed segment is transcribed immediately and accumulated. The per-listen 60s ceiling is swapped for a 15-min safety ceiling.
- On stop: flush the in-flight segment (`vad.pause()` + `submitUserSpeechOnPause`), await segment transcriptions in order, join, and resolve the pending `voice_listen` normally (→ thinking). No MCP signature change — just a longer transcript.
- **Go bridge keepalive:** the frontend pings `VoiceListenExtend(requestId)` every 30s while recording; `bridge.go` resets that request's `ListenTimeout` timer per ping. Non-recording listens never ping (unchanged). Works for remote browser clients via the existing reflected controller dispatch.

**2. MCP tool-timeout fix (`916beb9`)** — *the real cause of the "voice error" at ~60s*
- The claude CLI's MCP client aborts tool calls on **HTTP** MCP servers after a hardcoded **60s** default ("The operation timed out."), which killed `voice_listen` mid-recording — a client-side abort the Go keepalive can't prevent. Verified empirically (a 90s-blocking HTTP MCP stub tool fails at 60s by default, succeeds with `MCP_TOOL_TIMEOUT=300000`; stdio transport is unaffected).
- Fix: quant sets `MCP_TOOL_TIMEOUT=1200000` (20 min, > the 15-min ceiling) in every spawned session's env unless the user already exports one (`withMCPToolTimeout` in `process/manager.go`).

**3. Live transcript (`11c3874`)**
- `onRecordingTranscript` emits the accumulated per-slot segment texts as each Whisper result lands. VoicePane shows a dimmed/italic `you ▸ … · listening…` draft line that grows segment-by-segment and becomes the final line on stop (no duplicate). Live and final transcripts derive from the same join helper so they can't diverge.

**4. Agent-activated recording + spoken stop (`ef93344`)**
- `voice_listen` and `voice_converse` gain an optional `record: true` param (flows tool arg → `Bridge.Request` → `VoiceRequestEvent.record` → `listen({record:true})`, which starts already pinned). Lets the user say "I'm going to give a long answer, start recording" and have the agent open a pinned listen.
- **Spoken stop:** when a segment ends with a stop phrase it's stripped and the recording finalizes like pressing stop. Phrases: `stop recording`, `stop the recording`, `end recording`, `end the recording`, `finish recording`, `stop dictation` (matched at segment end, case-insensitive). Works for button-started recordings too.
- `VoicePersona` updated to teach the agent the convention; rec-button tooltip mentions the spoken stop.

## Known follow-up
Local Whisper tags non-English speech as `[NON-ENGLISH SPEECH]`; an STT language setting (Settings → Voice) would let Portuguese transcribe. Out of scope here.

## Verification
- `go build ./...`, `go vet ./...` pass.
- `go test ./internal/integration/voice/... ./internal/integration/process/...` pass, incl. `TestBridgeExtendResetsTimeout`, `TestBridgeExtendDoesNotOutliveResolveTimeout`, `TestBridgeRecordFlagRoundTrips`, `TestWithMCPToolTimeout`.
- `tsc --noEmit` clean, `npm run build` succeeds.
- Voice Playwright e2e 12/12 (incl. new record-mode + stop-phrase specs).
- Cross-platform: pure TS/Go, no platform-specific APIs.

**5. Per-session mindmap pane, ephemeral (`3f34ad1`)** — extracted from #69 (cherry-picked; the rest of that branch is not included)
- The mindmap pane open/close flag is now per-session and client-local: opening it on one session no longer pops it open on every other session, tab, and remote client (the `mindmap:pane` broadcast event is gone), and each session keeps its own toggle while you work.
- The flag is ephemeral — all panes start closed on a fresh launch (`MindmapPaneOpen` removed from config; old config files with the key are ignored on load). Board contents are untouched and stay persisted per session.
