### PR TITLE
feat(files): files_open MCP tool — agents can open a file in the user's UI

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -9,7 +9,8 @@
           "files open as real tabs — click a file in the tree and it opens in the center tab bar right next to your sessions, with its own unsaved-changes dot; switch tabs freely (drafts are kept), save with Cmd/Ctrl+S, and closing a tab with unsaved edits asks before discarding",
           "edit code with syntax highlighting — a CodeMirror editor that follows your theme (including imported VS Code themes) and loads language support on demand for over a hundred languages",
           "markdown opens rendered — tables, task lists, highlighted code fences, and live mermaid diagrams, with a rendered/source toggle so you can edit and watch the preview update as you type",
-          "view images and html too — images get a zoomable viewer with dimensions and file size; html files preview live in a sandboxed frame (scripts run isolated from the app) with the same preview/source toggle; svg works as both image and editable source"
+          "view images and html too — images get a zoomable viewer with dimensions and file size; html files preview live in a sandboxed frame (scripts run isolated from the app) with the same preview/source toggle; svg works as both image and editable source",
+          "agents can show you a file — a new files_open tool lets a session's agent open any file from its working directory as a tab and reveal it in the files panel tree, so 'take a look at this file' actually opens it for you"
         ],
         "fixes": [
           "file access from the new explorer is locked to each session's working directory — path traversal and symlink escapes are rejected, and the existing diff file read/write endpoints got the same hardening"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -172,6 +172,8 @@ function App() {
   openTabIdsRef.current = openTabIds;
   const fileTabDirtyRef = useRef(fileTabDirty);
   fileTabDirtyRef.current = fileTabDirty;
+  const handleOpenTabRef = useRef(handleOpenTab);
+  handleOpenTabRef.current = handleOpenTab;
   const embeddedTerminalMapRef = useRef(embeddedTerminalMap);
   embeddedTerminalMapRef.current = embeddedTerminalMap;
   const expandedSessionIdRef = useRef(expandedSessionId);
@@ -821,6 +823,27 @@ function App() {
           if (existing.includes(board)) return prev;
           return { ...prev, [sessionId]: [...existing, board] };
         });
+      }
+    );
+    return () => cancel && cancel();
+  }, []);
+
+  // Agent-driven "show the user this file" (files_open MCP tool): open the
+  // files panel for the owning session and open+activate the file tab. The
+  // effect mounts once, so the tab open goes through a ref (same pattern as
+  // fileTabDirtyRef above) to avoid capturing a stale handler.
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const w = window as any;
+    if (!w?.runtime?.EventsOn) return;
+    const cancel = w.runtime.EventsOn(
+      "files:open",
+      (d: { sessionId?: string; path?: string }) => {
+        if (!d || typeof d.sessionId !== "string" || d.sessionId === "") return;
+        if (typeof d.path !== "string" || d.path === "") return;
+        const { sessionId, path } = d;
+        setFilesPanelOpenMap((prev) => ({ ...prev, [sessionId]: true }));
+        handleOpenTabRef.current(makeFileTabId(sessionId, path));
       }
     );
     return () => cancel && cancel();

--- a/frontend/src/components/FileTree.tsx
+++ b/frontend/src/components/FileTree.tsx
@@ -137,6 +137,36 @@ export function FileTree({
     }
   }, [sessionId, loadDir]);
 
+  // Auto-reveal the open file: sequentially load each unloaded ancestor dir
+  // (parents must be in `data` before children can attach), expand them, then
+  // scroll the file into view (scrollTo waits internally for the row to
+  // appear). The cancelled flag keeps rapid openPath changes from
+  // interleaving their loads/expands.
+  useEffect(() => {
+    if (!openPath) return;
+    let cancelled = false;
+    const ancestors: string[] = [];
+    for (
+      let idx = openPath.indexOf("/");
+      idx !== -1;
+      idx = openPath.indexOf("/", idx + 1)
+    ) {
+      ancestors.push(openPath.slice(0, idx));
+    }
+    void (async () => {
+      for (const dir of ancestors) {
+        if (cancelled) return;
+        if (!loadedRef.current.has(dir)) await loadDir(dir);
+      }
+      if (cancelled) return;
+      for (const dir of ancestors) treeRef.current?.open(dir);
+      void treeRef.current?.scrollTo(openPath);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [openPath, loadDir]);
+
   function submitName(name: string) {
     const target = naming;
     setNaming(null);

--- a/internal/application/adapter/file_manager.go
+++ b/internal/application/adapter/file_manager.go
@@ -14,4 +14,5 @@ type FileManager interface {
 	CreateDir(sessionID, relPath string) error
 	RenamePath(sessionID, oldRelPath, newRelPath string) error
 	DeletePath(sessionID, relPath string, recursive bool) error
+	OpenFileForUser(sessionID, relPath string) error
 }

--- a/internal/application/service/file_service.go
+++ b/internal/application/service/file_service.go
@@ -275,6 +275,39 @@ func (s *fileManagerService) ReadFileBase64(sessionID, relPath string) (entity.F
 	}, nil
 }
 
+// OpenFileForUser asks the frontend to open a file as a tab and reveal it in
+// the files panel tree. The file must exist inside the session's working
+// directory and must not be a directory.
+func (s *fileManagerService) OpenFileForUser(sessionID, relPath string) error {
+	rel, err := normalizeRelPath(relPath)
+	if err != nil {
+		return err
+	}
+
+	root, err := s.sessionRoot(sessionID)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
+	info, err := root.Stat(rel)
+	if err != nil {
+		return fmt.Errorf("file not found: %s", relPath)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("cannot open a directory: %s", relPath)
+	}
+
+	if s.emitter != nil {
+		s.emitter.Emit("files:open", map[string]any{
+			"sessionId": sessionID,
+			"path":      filepath.ToSlash(rel),
+		})
+	}
+
+	return nil
+}
+
 // WriteFile writes content to an existing or new file. The parent directory
 // must already exist.
 func (s *fileManagerService) WriteFile(sessionID, relPath, content string) error {

--- a/internal/application/service/file_service_test.go
+++ b/internal/application/service/file_service_test.go
@@ -422,6 +422,74 @@ func TestFileServiceRenameRejections(t *testing.T) {
 	}
 }
 
+func TestFileServiceOpenFileForUser(t *testing.T) {
+	svc, dir, emitter := newTestFileService(t)
+
+	if err := os.MkdirAll(filepath.Join(dir, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "docs", "notes.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.OpenFileForUser("s1", "docs/notes.md"); err != nil {
+		t.Fatalf("OpenFileForUser: %v", err)
+	}
+
+	if len(emitter.names) != 1 || emitter.names[0] != "files:open" {
+		t.Fatalf("emitted events = %v, want exactly one files:open", emitter.names)
+	}
+	payload, ok := emitter.payloads[0].(map[string]any)
+	if !ok {
+		t.Fatalf("payload type = %T, want map[string]any", emitter.payloads[0])
+	}
+	if payload["sessionId"] != "s1" {
+		t.Fatalf("payload sessionId = %v, want s1", payload["sessionId"])
+	}
+	if payload["path"] != "docs/notes.md" {
+		t.Fatalf("payload path = %v, want docs/notes.md", payload["path"])
+	}
+}
+
+func TestFileServiceOpenFileForUserRejections(t *testing.T) {
+	svc, dir, emitter := newTestFileService(t)
+
+	if err := os.MkdirAll(filepath.Join(dir, "somedir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.OpenFileForUser("s1", "nope.txt"); err == nil {
+		t.Fatal("OpenFileForUser of missing file should error")
+	} else if !strings.Contains(err.Error(), "file not found") {
+		t.Fatalf("missing file error = %v, want 'file not found'", err)
+	}
+	if err := svc.OpenFileForUser("s1", "somedir"); err == nil {
+		t.Fatal("OpenFileForUser of a directory should error")
+	} else if !strings.Contains(err.Error(), "cannot open a directory") {
+		t.Fatalf("directory error = %v, want 'cannot open a directory'", err)
+	}
+	if err := svc.OpenFileForUser("s1", "../escape.txt"); err == nil {
+		t.Fatal("OpenFileForUser escape should error")
+	}
+
+	if len(emitter.names) != 0 {
+		t.Fatalf("failed opens must not emit, got %v", emitter.names)
+	}
+}
+
+func TestFileServiceOpenFileForUserNilEmitter(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewFileManagerService(&stubFindSession{dir: dir}, nil)
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.OpenFileForUser("s1", "a.txt"); err != nil {
+		t.Fatalf("OpenFileForUser with nil emitter: %v", err)
+	}
+}
+
 func TestFileServiceSessionNotFound(t *testing.T) {
 	svc, _, _ := newTestFileService(t)
 

--- a/internal/e2e/harness_test.go
+++ b/internal/e2e/harness_test.go
@@ -68,6 +68,7 @@ func newHarness(t *testing.T) *harness {
 		injector.RepoManager(),
 		injector.JobGroupManager(),
 		injector.MindmapManager(),
+		injector.FileManager(),
 		nil, // voice bridge — voice tools aren't exercised by these tests
 	)
 	if err := server.Start(); err != nil {

--- a/internal/e2e/voice_tools_test.go
+++ b/internal/e2e/voice_tools_test.go
@@ -75,6 +75,7 @@ func TestVoiceToolsRoundTrip(t *testing.T) {
 		injector.RepoManager(),
 		injector.JobGroupManager(),
 		injector.MindmapManager(),
+		injector.FileManager(),
 		bridge,
 	)
 	if err := server.Start(); err != nil {

--- a/internal/infra/application.go
+++ b/internal/infra/application.go
@@ -247,7 +247,7 @@ func Run(assets embed.FS, changelogData []byte) error {
 	processManager := injector.ProcessManager()
 
 	// Start MCP server for external AI tools to manage jobs.
-	mcpServer := quantmcp.NewQuantMCPServer(injector.JobManager(), injector.AgentManager(), injector.SessionManager(), injector.WorkspaceManager(), injector.RepoManager(), injector.JobGroupManager(), injector.MindmapManager(), voiceBridge)
+	mcpServer := quantmcp.NewQuantMCPServer(injector.JobManager(), injector.AgentManager(), injector.SessionManager(), injector.WorkspaceManager(), injector.RepoManager(), injector.JobGroupManager(), injector.MindmapManager(), injector.FileManager(), voiceBridge)
 	mcpPort := mcpServer.Port()
 	fmt.Printf("[quant] MCP server on port %d → http://localhost:%d/mcp\n", mcpPort, mcpPort)
 	if mcpPort != quantmcp.DefaultPort {

--- a/internal/integration/mcp/server.go
+++ b/internal/integration/mcp/server.go
@@ -40,6 +40,7 @@ type QuantMCPServer struct {
 	repoManager      appAdapter.RepoManager
 	jobGroupManager  appAdapter.JobGroupManager
 	mindmapManager   appAdapter.MindmapManager
+	fileManager      appAdapter.FileManager
 	voiceBridge      *voice.Bridge
 	httpServer       *http.Server
 	listener         net.Listener
@@ -48,7 +49,7 @@ type QuantMCPServer struct {
 
 // NewQuantMCPServer creates a new MCP server with all management tools registered.
 // It tries the default port first, then probes up to 10 consecutive ports to find one that's free.
-func NewQuantMCPServer(jobManager appAdapter.JobManager, agentManager appAdapter.AgentManager, sessionManager appAdapter.SessionManager, workspaceManager appAdapter.WorkspaceManager, repoManager appAdapter.RepoManager, jobGroupManager appAdapter.JobGroupManager, mindmapManager appAdapter.MindmapManager, voiceBridge *voice.Bridge) *QuantMCPServer {
+func NewQuantMCPServer(jobManager appAdapter.JobManager, agentManager appAdapter.AgentManager, sessionManager appAdapter.SessionManager, workspaceManager appAdapter.WorkspaceManager, repoManager appAdapter.RepoManager, jobGroupManager appAdapter.JobGroupManager, mindmapManager appAdapter.MindmapManager, fileManager appAdapter.FileManager, voiceBridge *voice.Bridge) *QuantMCPServer {
 	mcpServer := server.NewMCPServer("quant", "1.0.0")
 
 	s := &QuantMCPServer{
@@ -59,6 +60,7 @@ func NewQuantMCPServer(jobManager appAdapter.JobManager, agentManager appAdapter
 		repoManager:      repoManager,
 		jobGroupManager:  jobGroupManager,
 		mindmapManager:   mindmapManager,
+		fileManager:      fileManager,
 		voiceBridge:      voiceBridge,
 	}
 
@@ -1013,6 +1015,20 @@ Example flow: run_job("health-check") → get_pipeline_status(runId) shows:
 		),
 		s.handleMindmapListBoards,
 	)
+
+	// ---------------------------------------------------------------------------
+	// Files tools — open files in the user's UI.
+	// ---------------------------------------------------------------------------
+
+	// files_open
+	mcpServer.AddTool(
+		mcp.NewTool("files_open",
+			mcp.WithDescription(`Open a file in the user's quant UI: shows it as a file tab and reveals it in the files panel file tree. Use it to point the user at a specific file. Path is relative to the session's working directory.`),
+			mcp.WithString("path", mcp.Required(), mcp.Description("File path relative to the session's working directory, e.g. \"internal/app/foo.go\".")),
+			mcp.WithString("sessionId", mcp.Description("Open the file in ANOTHER session's UI by its session id. Omit to open in THIS session's UI.")),
+		),
+		s.handleFilesOpen,
+	)
 }
 
 // ---------------------------------------------------------------------------
@@ -1845,6 +1861,28 @@ func (s *QuantMCPServer) handleMindmapListBoards(ctx context.Context, request mc
 	}
 
 	return marshalResult(result)
+}
+
+// ---------------------------------------------------------------------------
+// Files handlers
+// ---------------------------------------------------------------------------
+
+func (s *QuantMCPServer) handleFilesOpen(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path, err := requiredString(request, "path")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	scopeType, scopeID := s.scopeForArgs(ctx, request.GetArguments())
+	if scopeType != "session" || scopeID == "" {
+		return mcp.NewToolResultError("no session in scope — pass sessionId or call from within a quant session"), nil
+	}
+
+	if err := s.fileManager.OpenFileForUser(scopeID, path); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("opened %s in the user's UI", path)), nil
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

A new `files_open` MCP tool so a session's agent can show the user a file: it opens as a center file tab (rendered for markdown, editor for code) and is revealed in the right files panel tree — panel auto-opens, ancestors auto-expand, tree scrolls to the file. Works on desktop and remote clients via the existing event fan-out.

- Tool: `files_open(path, sessionId?)` — session defaults to the caller (X-Quant-Session), same scoping as the mindmap tools
- Validation in the sandboxed FileManager service: path normalized + confined via os.Root, errors for missing files, directories, and escapes; the UI event only fires on success
- Frontend: `files:open` subscription opens the panel + tab; FileTree now auto-reveals the open path (lazy-loads ancestor dirs, expands, scrolls) — this also improves plain UI opens from recents
- Changelog: appended to the v3.1.33 entry (still untagged)

## Verification

E2E in a sandboxed instance: called `files_open` over the MCP HTTP API with the session header — files panel opened, `docs/notes.md` tab appeared and activated rendered, tree expanded `docs` and highlighted the file. Probes: missing file → "file not found", `../../etc/passwd` → "path escapes the session directory", directory → "cannot open a directory", no session scope → clear error, explicit `sessionId` arg → works. `go test` green, frontend `tsc` + build green.