### PR TITLE
feat(sessions): adopt external claude sessions + sync /rename

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,18 @@
 {
   "entries": [
     {
+      "version": "v3.1.35",
+      "date": "2026-06-11",
+      "changes": {
+        "features": [
+          "adopt claude sessions born outside quant — \"new session\" gains a \"resume an existing session\" option: pick from the untracked claude conversations found for the repo's directory (with first message and age) or paste a session id, and quant resumes that conversation instead of starting fresh",
+          "re-point or detach a session's conversation — right-click a stopped session and \"change claude session id\" to attach a different claude conversation, or detach it so the next start begins a fresh one",
+          "agents can adopt sessions too — create_session accepts a claudeSessionId, plus new list_adoptable_sessions and set_session_claude_id MCP tools",
+          "renaming a session now renames the claude conversation too — quant runs /rename inside the running session so claude's own session title stays in sync"
+        ]
+      }
+    },
+    {
       "version": "v3.1.33",
       "date": "2026-06-10",
       "changes": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import { TabBar } from "./components/TabBar";
 import { MoveSessionModal } from "./components/MoveSessionModal";
 import { ConfirmModal } from "./components/ConfirmModal";
 import { RenameModal } from "./components/RenameModal";
+import { ChangeSessionIdModal } from "./components/ChangeSessionIdModal";
 import { RenameTaskModal } from "./components/RenameTaskModal";
 import { Settings } from "./components/Settings";
 import { DiffView } from "./components/DiffView";
@@ -72,6 +73,7 @@ type ModalState =
   | { type: "moveSession"; sessionId: string; repoId: string }
   | { type: "confirm"; message: string; onConfirm: () => void; confirmLabel?: string }
   | { type: "renameSession"; sessionId: string; currentName: string }
+  | { type: "changeClaudeSession"; sessionId: string }
   | { type: "renameTask"; taskId: string; currentTag: string; currentName: string }
   | { type: "gitCommit"; sessionId: string; sessionName: string }
   | { type: "gitPull"; sessionId: string; currentBranch: string }
@@ -1512,6 +1514,10 @@ function App() {
     }
   }
 
+  function handleChangeClaudeSession(sessionId: string) {
+    setModal({ type: "changeClaudeSession", sessionId });
+  }
+
   function handleMoveSession(sessionId: string, repoId: string) {
     setModal({ type: "moveSession", sessionId, repoId });
   }
@@ -2491,6 +2497,7 @@ function App() {
         onDoubleClickSession={handleDoubleClickSession}
         onRenameTask={handleRenameTask}
         onRenameSession={handleRenameSession}
+        onChangeClaudeSession={handleChangeClaudeSession}
         onDropSession={(sessionId, targetTaskId) => handleMoveSessionSelect(sessionId, targetTaskId)}
         boardsBySession={boardsBySession}
         activeBoardBySession={activeBoardBySession}
@@ -2693,6 +2700,21 @@ function App() {
           onCancel={() => setModal({ type: "none" })}
         />
       )}
+
+      {modal.type === "changeClaudeSession" && (() => {
+        const target = findSession(modal.sessionId, sessionsByRepo, sessionsByTask);
+        if (!target) return null;
+        return (
+          <ChangeSessionIdModal
+            session={target}
+            onDone={async () => {
+              setModal({ type: "none" });
+              await loadAll();
+            }}
+            onCancel={() => setModal({ type: "none" })}
+          />
+        );
+      })()}
 
       {modal.type === "renameTask" && (
         <RenameTaskModal

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -31,6 +31,7 @@ import type {
   RemoteStatus,
   VoiceSpeechResult,
   VoicePingResult,
+  ExternalSession,
 } from "./types";
 
 // These functions map to Go controller methods bound via Wails.
@@ -190,6 +191,18 @@ export function moveSessionToTask(sessionId: string, newTaskId: string): Promise
 
 export function renameSession(id: string, newName: string): Promise<void> {
   return callGo(PKG, SESSION_CTRL, "RenameSession", id, newName);
+}
+
+export function listAdoptableSessions(directory: string): Promise<ExternalSession[]> {
+  return callGo<ExternalSession[] | null>(PKG, SESSION_CTRL, "ListAdoptableSessions", directory).then(
+    (r) => r ?? []
+  );
+}
+
+// Re-point a stopped quant session at a different claude conversation;
+// empty claudeId detaches (fresh conversation on next start).
+export function setClaudeSessionId(sessionId: string, claudeId: string): Promise<void> {
+  return callGo(PKG, SESSION_CTRL, "SetClaudeSessionID", sessionId, claudeId);
 }
 
 export function checkBranchExists(repoId: string, branchName: string): Promise<boolean> {

--- a/frontend/src/components/ChangeSessionIdModal.tsx
+++ b/frontend/src/components/ChangeSessionIdModal.tsx
@@ -1,0 +1,261 @@
+import { useState, useEffect } from "react";
+import type { Session, ExternalSession } from "../types";
+import * as api from "../api";
+
+const font = "'JetBrains Mono', monospace";
+
+export const CLAUDE_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (isNaN(then)) return "";
+  const sec = Math.floor((Date.now() - then) / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
+}
+
+// List of adoptable claude conversations for a directory plus a paste-an-id
+// input. A pasted valid UUID takes precedence over the list selection.
+export function ClaudeSessionPicker({
+  directory,
+  selectedId,
+  onSelect,
+  pastedId,
+  onPaste,
+  disabled,
+}: {
+  directory: string;
+  selectedId: string;
+  onSelect: (id: string) => void;
+  pastedId: string;
+  onPaste: (v: string) => void;
+  disabled?: boolean;
+}) {
+  const [list, setList] = useState<ExternalSession[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setList(null);
+    setLoadError(null);
+    if (!directory) {
+      setList([]);
+      return;
+    }
+    let cancelled = false;
+    api.listAdoptableSessions(directory)
+      .then((r) => { if (!cancelled) setList(r); })
+      .catch((err) => { if (!cancelled) { setList([]); setLoadError(String(err)); } });
+    return () => { cancelled = true; };
+  }, [directory]);
+
+  const pasted = pastedId.trim();
+  const pastedValid = CLAUDE_UUID_RE.test(pasted);
+
+  return (
+    <div className="flex flex-col gap-2" style={{ opacity: disabled ? 0.4 : 1 }}>
+      <div style={{ border: "1px solid var(--q-border)", maxHeight: 180, overflowY: "auto" }}>
+        {list === null && !loadError && (
+          <div className="px-3 py-2 text-[10px]" style={{ color: "var(--q-fg-muted)", fontFamily: font }}>
+            loading...
+          </div>
+        )}
+        {loadError && (
+          <div className="px-3 py-2 text-[10px]" style={{ color: "var(--q-error)", fontFamily: font }}>
+            {loadError}
+          </div>
+        )}
+        {list !== null && !loadError && list.length === 0 && (
+          <div className="px-3 py-2 text-[10px]" style={{ color: "var(--q-fg-muted)", fontFamily: font }}>
+            no untracked claude sessions found for this repo's directory
+          </div>
+        )}
+        {list?.map((s, i) => {
+          const selected = !pastedValid && selectedId === s.id;
+          return (
+            <button
+              key={s.id}
+              type="button"
+              disabled={disabled}
+              onClick={() => onSelect(selected ? "" : s.id)}
+              className="w-full flex items-center gap-2 px-3 py-2 text-left transition-colors"
+              style={{
+                fontFamily: font,
+                fontSize: 11,
+                color: selected ? "var(--q-accent)" : "var(--q-fg)",
+                backgroundColor: selected ? "var(--q-bg-hover)" : "transparent",
+                border: "none",
+                borderBottom: i < (list?.length ?? 0) - 1 ? "1px solid var(--q-border)" : "none",
+                cursor: disabled ? "default" : "pointer",
+              }}
+              onMouseEnter={(e) => {
+                if (!selected && !disabled) e.currentTarget.style.backgroundColor = "var(--q-bg-hover)";
+              }}
+              onMouseLeave={(e) => {
+                if (!selected) e.currentTarget.style.backgroundColor = "transparent";
+              }}
+            >
+              <span style={{ color: "var(--q-accent)", flexShrink: 0 }}>{selected ? "(x)" : "( )"}</span>
+              <span style={{ flexShrink: 0 }}>{s.id.slice(0, 8)}</span>
+              <span
+                className="flex-1 overflow-hidden whitespace-nowrap"
+                style={{ textOverflow: "ellipsis", color: "var(--q-fg-secondary)" }}
+              >
+                {s.firstMessage || "(no messages)"}
+              </span>
+              <span style={{ color: "var(--q-fg-muted)", fontSize: 9, flexShrink: 0 }}>
+                {relativeTime(s.modTime)}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <label className="block">
+        <span className="text-[10px] lowercase" style={{ color: "var(--q-fg-secondary)", fontFamily: font }}>
+          or paste a session id
+        </span>
+        <input
+          value={pastedId}
+          onChange={(e) => onPaste(e.target.value)}
+          disabled={disabled}
+          placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+          className="mt-1 block w-full px-3 py-2 text-xs focus:outline-none"
+          style={{
+            backgroundColor: "var(--q-bg)",
+            border: "1px solid var(--q-border)",
+            color: "var(--q-fg)",
+            fontFamily: font,
+          }}
+          onFocus={(e) => (e.currentTarget.style.borderColor = "var(--q-accent)")}
+          onBlur={(e) => (e.currentTarget.style.borderColor = "var(--q-border)")}
+        />
+        {pasted !== "" && !pastedValid && (
+          <span className="block mt-1 text-[9px]" style={{ color: "var(--q-warning)", fontFamily: font }}>
+            not a valid session id (expects a uuid)
+          </span>
+        )}
+      </label>
+    </div>
+  );
+}
+
+interface Props {
+  session: Session;
+  onDone: () => void;
+  onCancel: () => void;
+}
+
+export function ChangeSessionIdModal({ session, onDone, onCancel }: Props) {
+  const [selectedId, setSelectedId] = useState("");
+  const [pastedId, setPastedId] = useState("");
+  const [detach, setDetach] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const directory = session.worktreePath || session.directory;
+  const pasted = pastedId.trim();
+  const pastedValid = CLAUDE_UUID_RE.test(pasted);
+  const chosenId = detach ? "" : pastedValid ? pasted.toLowerCase() : selectedId;
+  const canSubmit = detach || chosenId !== "";
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await api.setClaudeSessionId(session.id, chosenId);
+      onDone();
+    } catch (err) {
+      setError(String(err));
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ backgroundColor: "var(--q-modal-backdrop)" }}>
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md p-6 max-h-[90vh] flex flex-col gap-4 overflow-y-auto"
+        style={{
+          backgroundColor: "var(--q-bg)",
+          border: "1px solid var(--q-border)",
+          fontFamily: font,
+        }}
+      >
+        <label className="block text-[10px] lowercase" style={{ color: "var(--q-fg-secondary)" }}>
+          // change claude session id
+        </label>
+
+        <div className="text-[10px]" style={{ color: "var(--q-fg-muted)" }}>
+          current:{" "}
+          <span style={{ color: session.claudeConvId ? "var(--q-accent)" : "var(--q-fg-muted)" }}>
+            {session.claudeConvId || "none"}
+          </span>
+        </div>
+
+        <ClaudeSessionPicker
+          directory={directory}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+          pastedId={pastedId}
+          onPaste={setPastedId}
+          disabled={detach}
+        />
+
+        <button
+          type="button"
+          onClick={() => setDetach(!detach)}
+          className="flex items-center gap-2 text-left"
+          style={{ background: "none", border: "none", padding: 0, cursor: "pointer" }}
+        >
+          <span style={{ color: "var(--q-accent)", fontSize: 11, fontFamily: font }}>
+            {detach ? "(x)" : "( )"}
+          </span>
+          <span style={{ color: detach ? "var(--q-accent)" : "var(--q-fg)", fontSize: 11, fontFamily: font }}>
+            detach — start a fresh conversation next run
+          </span>
+        </button>
+
+        {error && (
+          <div
+            className="px-3 py-2 text-[10px]"
+            style={{
+              color: "var(--q-error)",
+              backgroundColor: "var(--q-error-bg)",
+              border: "1px solid var(--q-border)",
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 text-xs lowercase transition-colors"
+            style={{ color: "var(--q-fg-secondary)" }}
+            onMouseEnter={(e) => (e.currentTarget.style.color = "var(--q-fg)")}
+            onMouseLeave={(e) => (e.currentTarget.style.color = "var(--q-fg-secondary)")}
+          >
+            cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit || submitting}
+            className="px-4 py-2 text-xs lowercase transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            style={{ backgroundColor: "var(--q-accent)", color: "var(--q-bg)", fontWeight: 500 }}
+          >
+            {submitting ? "saving..." : detach ? "detach" : "attach"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/NewSessionModal.tsx
+++ b/frontend/src/components/NewSessionModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import type { Repo, Task, CreateSessionRequest, SessionType, Config } from "../types";
 import * as api from "../api";
+import { ClaudeSessionPicker, CLAUDE_UUID_RE } from "./ChangeSessionIdModal";
 
 const MODEL_OPTIONS = ["cli default", "claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5-20251001"];
 
@@ -28,6 +29,11 @@ export function NewSessionModal({
   const [taskId, setTaskId] = useState(defaultTaskId ?? "");
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [configLoaded, setConfigLoaded] = useState(false);
+
+  // Conversation: start fresh, or adopt an existing claude CLI conversation.
+  const [convMode, setConvMode] = useState<"new" | "resume">("new");
+  const [selectedClaudeId, setSelectedClaudeId] = useState("");
+  const [pastedClaudeId, setPastedClaudeId] = useState("");
 
   // Advanced options — initialized from config defaults
   const [useWorktree, setUseWorktree] = useState(false);
@@ -61,6 +67,16 @@ export function NewSessionModal({
   const selectedRepo = repos.find((r) => r.id === repoId);
   const selectedTask = tasks.find((t) => t.id === taskId);
 
+  // A pasted valid UUID takes precedence over the list selection.
+  const pastedClaude = pastedClaudeId.trim();
+  const claudeSessionId =
+    sessionType === "claude" && convMode === "resume"
+      ? CLAUDE_UUID_RE.test(pastedClaude)
+        ? pastedClaude.toLowerCase()
+        : selectedClaudeId
+      : "";
+  const adopting = claudeSessionId !== "";
+
   function buildRequest(): CreateSessionRequest {
     return {
       name: name.trim().toLowerCase(),
@@ -68,13 +84,14 @@ export function NewSessionModal({
       repoId,
       taskId,
       sessionType,
-      useWorktree,
+      useWorktree: adopting ? false : useWorktree,
       skipPermissions: sessionType === "claude" ? skipPermissions : false,
       autoPull,
       pullBranch,
       branchNamePattern,
       model: sessionType === "claude" ? model : "",
       extraCliArgs: sessionType === "claude" ? extraCliArgs : "",
+      ...(adopting ? { claudeSessionId } : {}),
     };
   }
 
@@ -86,9 +103,11 @@ export function NewSessionModal({
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!name.trim() || !repoId || !taskId) return;
+    if (sessionType === "claude" && convMode === "resume" && !adopting) return;
 
     // If worktree enabled and not already confirmed, check if branch exists.
-    if (useWorktree && !branchExistsWarning) {
+    // Adoption forces worktree off, so the check is irrelevant then.
+    if (useWorktree && !adopting && !branchExistsWarning) {
       setChecking(true);
       try {
         const exists = await api.checkBranchExists(repoId, resolveBranchName());
@@ -175,7 +194,7 @@ export function NewSessionModal({
             <span className="text-[10px] lowercase block mb-1" style={{ color: "var(--q-fg-secondary)" }}>repo</span>
             <CustomSelect
               value={repoId}
-              onChange={(v) => { setRepoId(v); setTaskId(""); }}
+              onChange={(v) => { setRepoId(v); setTaskId(""); setSelectedClaudeId(""); }}
               options={repos.map((r) => ({ value: r.id, label: `${r.name} (${r.path})` }))}
               placeholder="select a repo"
               displayValue={selectedRepo ? `${selectedRepo.name} (${selectedRepo.path})` : ""}
@@ -223,6 +242,51 @@ export function NewSessionModal({
             />
           </label>
 
+          {/* conversation — new vs adopt an existing claude session */}
+          {sessionType === "claude" && (
+            <div>
+              <span className="text-[10px] lowercase block mb-1" style={{ color: "var(--q-fg-secondary)" }}>conversation</span>
+              <div className="flex flex-col gap-2">
+                {([
+                  { key: "new", label: "new conversation" },
+                  { key: "resume", label: "resume an existing session" },
+                ] as const).map((opt) => (
+                  <button
+                    key={opt.key}
+                    type="button"
+                    onClick={() => setConvMode(opt.key)}
+                    className="flex items-center gap-2 text-left"
+                    style={{ background: "none", border: "none", padding: 0, cursor: "pointer" }}
+                  >
+                    <span style={{ color: "var(--q-accent)", fontSize: 11, fontFamily: "'JetBrains Mono', monospace" }}>
+                      {convMode === opt.key ? "(x)" : "( )"}
+                    </span>
+                    <span
+                      style={{
+                        color: convMode === opt.key ? "var(--q-accent)" : "var(--q-fg)",
+                        fontSize: 11,
+                        fontFamily: "'JetBrains Mono', monospace",
+                      }}
+                    >
+                      {opt.label}
+                    </span>
+                  </button>
+                ))}
+              </div>
+              {convMode === "resume" && (
+                <div className="mt-2">
+                  <ClaudeSessionPicker
+                    directory={selectedRepo?.path ?? ""}
+                    selectedId={selectedClaudeId}
+                    onSelect={setSelectedClaudeId}
+                    pastedId={pastedClaudeId}
+                    onPaste={setPastedClaudeId}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
           {/* advanced options toggle */}
           <button
             type="button"
@@ -246,7 +310,13 @@ export function NewSessionModal({
               {/* session section */}
               <div className="flex flex-col gap-3">
                 <span style={{ color: "var(--q-accent)", fontSize: 10, fontWeight: 700 }}>session</span>
-                <AdvancedToggle label="use worktree" description="create isolated git worktree" checked={useWorktree} onChange={setUseWorktree} />
+                <AdvancedToggle
+                  label="use worktree"
+                  description={adopting ? "unavailable when adopting — resumes in the original directory" : "create isolated git worktree"}
+                  checked={adopting ? false : useWorktree}
+                  onChange={setUseWorktree}
+                  disabled={adopting}
+                />
                 {sessionType === "claude" && (
                   <AdvancedToggle label="skip permissions" description="pass --dangerously-skip-permissions" checked={skipPermissions} onChange={setSkipPermissions} />
                 )}
@@ -339,7 +409,7 @@ export function NewSessionModal({
             </button>
             <button
               type="submit"
-              disabled={!name.trim() || !repoId || !taskId || checking}
+              disabled={!name.trim() || !repoId || !taskId || checking || (sessionType === "claude" && convMode === "resume" && !adopting)}
               className="px-4 py-2 text-xs lowercase transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
               style={{
                 backgroundColor: "var(--q-accent)",
@@ -358,20 +428,22 @@ export function NewSessionModal({
 
 // --- Advanced option row components ---
 
-function AdvancedToggle({ label, description, checked, onChange }: {
+function AdvancedToggle({ label, description, checked, onChange, disabled }: {
   label: string;
   description: string;
   checked: boolean;
   onChange: (v: boolean) => void;
+  disabled?: boolean;
 }) {
   return (
-    <div className="flex items-center justify-between">
+    <div className="flex items-center justify-between" style={{ opacity: disabled ? 0.4 : 1 }}>
       <div className="flex flex-col" style={{ gap: 2 }}>
         <span style={{ color: "var(--q-fg)", fontSize: 11, fontFamily: "'JetBrains Mono', monospace" }}>{label}</span>
         <span style={{ color: "var(--q-fg-muted)", fontSize: 9, fontFamily: "'JetBrains Mono', monospace" }}>{description}</span>
       </div>
       <button
         type="button"
+        disabled={disabled}
         onClick={() => onChange(!checked)}
         className="flex items-center justify-center"
         style={{
@@ -379,6 +451,7 @@ function AdvancedToggle({ label, description, checked, onChange }: {
           height: 14,
           backgroundColor: "var(--q-bg)",
           border: `1px solid ${checked ? "var(--q-accent)" : "var(--q-border)"}`,
+          cursor: disabled ? "default" : "pointer",
         }}
       >
         {checked && <span style={{ color: "var(--q-accent)", fontSize: 10, lineHeight: 1 }}>x</span>}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -41,6 +41,7 @@ interface SidebarProps {
   onUnarchiveTask: (taskId: string) => void;
   onRenameTask?: (taskId: string, currentTag: string, currentName: string) => void;
   onRenameSession?: (sessionId: string, currentName: string) => void;
+  onChangeClaudeSession?: (sessionId: string) => void;
   onMoveSession?: (sessionId: string, repoId: string) => void;
   onDoubleClickSession?: (id: string) => void;
   onDropSession?: (sessionId: string, targetTaskId: string) => void;
@@ -135,6 +136,7 @@ export function Sidebar({
   onUnarchiveTask,
   onRenameTask,
   onRenameSession,
+  onChangeClaudeSession,
   onMoveSession,
   onDoubleClickSession,
   onDropSession,
@@ -385,6 +387,17 @@ export function Sidebar({
         label: "rename",
         onClick: () => onRenameSession?.(session.id, session.name),
       });
+
+      // Re-point a stopped claude session at a different claude conversation.
+      if (session.sessionType === "claude" && displaySt !== "running" && onChangeClaudeSession) {
+        items.push({
+          type: "item",
+          icon: "$",
+          iconColor: "var(--q-fg-secondary)",
+          label: "change claude session id",
+          onClick: () => onChangeClaudeSession(session.id),
+        });
+      }
 
       // Only show "move to task" if there are >= 2 tasks in the repo
       const repoTasks = tasksByRepo[session.repoId] ?? [];

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -83,6 +83,19 @@ export interface CreateSessionRequest {
   extraCliArgs: string;
   directoryOverride?: string;
   workspaceId?: string;
+  // When set, the new session adopts (resumes) this existing claude
+  // conversation; the backend overrides the working directory to the
+  // transcript's cwd and rejects worktree mode.
+  claudeSessionId?: string;
+}
+
+// An on-disk claude CLI conversation not yet tracked by quant.
+export interface ExternalSession {
+  id: string;
+  cwd: string;
+  firstMessage: string;
+  modTime: string;
+  sizeBytes: number;
 }
 
 // --- Jobs ---

--- a/frontend/wailsjs/go/controller/sessionController.d.ts
+++ b/frontend/wailsjs/go/controller/sessionController.d.ts
@@ -35,6 +35,8 @@ export function GitPush(arg1:string):Promise<void>;
 
 export function GitSaveFileContent(arg1:string,arg2:string,arg3:string):Promise<void>;
 
+export function ListAdoptableSessions(arg1:string):Promise<Array<dto.ExternalSessionResponse>>;
+
 export function ListBranches(arg1:string):Promise<Array<string>>;
 
 export function ListSessions():Promise<Array<dto.SessionResponse>>;
@@ -60,6 +62,8 @@ export function ResumeSession(arg1:string,arg2:number,arg3:number):Promise<void>
 export function RunShortcut(arg1:string,arg2:string):Promise<void>;
 
 export function SendMessage(arg1:string,arg2:string):Promise<void>;
+
+export function SetClaudeSessionID(arg1:string,arg2:string):Promise<void>;
 
 export function StartAssistantSession(arg1:string):Promise<dto.SessionResponse>;
 

--- a/frontend/wailsjs/go/controller/sessionController.js
+++ b/frontend/wailsjs/go/controller/sessionController.js
@@ -66,6 +66,10 @@ export function GitSaveFileContent(arg1, arg2, arg3) {
   return window['go']['controller']['sessionController']['GitSaveFileContent'](arg1, arg2, arg3);
 }
 
+export function ListAdoptableSessions(arg1) {
+  return window['go']['controller']['sessionController']['ListAdoptableSessions'](arg1);
+}
+
 export function ListBranches(arg1) {
   return window['go']['controller']['sessionController']['ListBranches'](arg1);
 }
@@ -116,6 +120,10 @@ export function RunShortcut(arg1, arg2) {
 
 export function SendMessage(arg1, arg2) {
   return window['go']['controller']['sessionController']['SendMessage'](arg1, arg2);
+}
+
+export function SetClaudeSessionID(arg1, arg2) {
+  return window['go']['controller']['sessionController']['SetClaudeSessionID'](arg1, arg2);
 }
 
 export function StartAssistantSession(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -383,6 +383,7 @@ export namespace dto {
 	    extraCliArgs: string;
 	    directoryOverride: string;
 	    workspaceId: string;
+	    claudeSessionId: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new CreateSessionRequest(source);
@@ -404,6 +405,7 @@ export namespace dto {
 	        this.extraCliArgs = source["extraCliArgs"];
 	        this.directoryOverride = source["directoryOverride"];
 	        this.workspaceId = source["workspaceId"];
+	        this.claudeSessionId = source["claudeSessionId"];
 	    }
 	}
 	export class CreateTaskRequest {
@@ -452,6 +454,26 @@ export namespace dto {
 	        this.path = source["path"];
 	        this.status = source["status"];
 	        this.oldPath = source["oldPath"];
+	    }
+	}
+	export class ExternalSessionResponse {
+	    id: string;
+	    cwd: string;
+	    firstMessage: string;
+	    modTime: string;
+	    sizeBytes: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new ExternalSessionResponse(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.cwd = source["cwd"];
+	        this.firstMessage = source["firstMessage"];
+	        this.modTime = source["modTime"];
+	        this.sizeBytes = source["sizeBytes"];
 	    }
 	}
 	export class FileBase64Response {

--- a/internal/application/adapter/session_manager.go
+++ b/internal/application/adapter/session_manager.go
@@ -25,6 +25,8 @@ type SessionManager interface {
 	GetSessionOutput(id string) (string, error)
 	UpdateSessionTask(sessionID string, newTaskID string) error
 	RenameSession(id string, newName string) error
+	SetClaudeSessionID(sessionID string, claudeID string) error
+	ListAdoptableSessions(directory string) ([]entity.ExternalClaudeSession, error)
 	UpdateSessionWorkspace(id string, workspaceID string) error
 	CheckBranchExists(repoID string, branchName string) (bool, error)
 	RunShortcut(sessionID string, command string) error

--- a/internal/application/service/claude_transcripts.go
+++ b/internal/application/service/claude_transcripts.go
@@ -1,0 +1,215 @@
+package service
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"quant/internal/domain/entity"
+)
+
+const (
+	// transcriptScanLimit caps how many leading lines are scanned for metadata —
+	// the cwd and first user message always appear near the top.
+	transcriptScanLimit = 100
+
+	// transcriptMaxLineSize is the scanner buffer cap. Transcript lines can be
+	// huge (full tool outputs are inlined), far beyond bufio's 64KB default.
+	transcriptMaxLineSize = 10 * 1024 * 1024
+
+	// maxAdoptableSessions caps how many transcripts listForDir returns.
+	maxAdoptableSessions = 50
+
+	// firstMessageMaxRunes is the truncation length for the first-message preview.
+	firstMessageMaxRunes = 140
+)
+
+// claudeTranscripts reads claude CLI transcript files stored under
+// <baseDir>/<project-slug>/<session-uuid>.jsonl. baseDir is injectable for tests.
+type claudeTranscripts struct {
+	baseDir string
+}
+
+// newClaudeTranscripts returns a transcript store rooted at ~/.claude/projects.
+func newClaudeTranscripts() claudeTranscripts {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return claudeTranscripts{}
+	}
+	return claudeTranscripts{baseDir: filepath.Join(homeDir, ".claude", "projects")}
+}
+
+// projectSlug converts an absolute directory path into the directory name the
+// claude CLI uses under ~/.claude/projects: every rune that is not an ASCII
+// letter or digit becomes '-'.
+func projectSlug(dir string) string {
+	var b strings.Builder
+	b.Grow(len(dir))
+	for _, r := range dir {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
+}
+
+// transcriptLine is the minimal shape of a transcript jsonl line.
+type transcriptLine struct {
+	Type    string          `json:"type"`
+	Cwd     string          `json:"cwd"`
+	Message json.RawMessage `json:"message"`
+}
+
+// messageText extracts the text of a transcript message: content is either a
+// plain string or an array of blocks like {type:"text", text:"..."}.
+func messageText(raw json.RawMessage) string {
+	var msg struct {
+		Content json.RawMessage `json:"content"`
+	}
+	if json.Unmarshal(raw, &msg) != nil || len(msg.Content) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(msg.Content, &s) == nil {
+		return s
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(msg.Content, &blocks) == nil {
+		for _, b := range blocks {
+			if b.Type == "text" && b.Text != "" {
+				return b.Text
+			}
+		}
+	}
+	return ""
+}
+
+// truncateRunes shortens s to at most n runes.
+func truncateRunes(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n])
+}
+
+// scanTranscript reads the leading lines of a transcript and returns the first
+// non-empty cwd and the first real user message text. Messages whose text
+// starts with "<" are skipped — those are command/caveat wrapper entries, not
+// what the user typed.
+func (t claudeTranscripts) scanTranscript(path string) (cwd string, firstMessage string, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to open transcript: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), transcriptMaxLineSize)
+	for i := 0; i < transcriptScanLimit && scanner.Scan(); i++ {
+		var line transcriptLine
+		if json.Unmarshal(scanner.Bytes(), &line) != nil {
+			continue
+		}
+		if cwd == "" && line.Cwd != "" {
+			cwd = line.Cwd
+		}
+		if firstMessage == "" && line.Type == "user" {
+			text := strings.TrimSpace(messageText(line.Message))
+			if text != "" && !strings.HasPrefix(text, "<") {
+				firstMessage = text
+			}
+		}
+		if cwd != "" && firstMessage != "" {
+			break
+		}
+	}
+	if scanErr := scanner.Err(); scanErr != nil && cwd == "" {
+		return "", "", fmt.Errorf("failed to read transcript: %w", scanErr)
+	}
+	if cwd == "" {
+		return "", "", fmt.Errorf("no cwd found in transcript %s", filepath.Base(path))
+	}
+	return cwd, firstMessage, nil
+}
+
+// transcriptCwd returns the working directory recorded in a transcript file.
+func (t claudeTranscripts) transcriptCwd(path string) (string, error) {
+	cwd, _, err := t.scanTranscript(path)
+	return cwd, err
+}
+
+// findByID locates a transcript by claude session UUID across all project slugs
+// and returns its path and recorded cwd.
+func (t claudeTranscripts) findByID(id string) (path string, cwd string, err error) {
+	matches, err := filepath.Glob(filepath.Join(t.baseDir, "*", id+".jsonl"))
+	if err != nil {
+		return "", "", fmt.Errorf("failed to search claude transcripts: %w", err)
+	}
+	if len(matches) == 0 {
+		return "", "", fmt.Errorf("no claude session %s found on this machine", id)
+	}
+	cwd, err = t.transcriptCwd(matches[0])
+	if err != nil {
+		return "", "", err
+	}
+	return matches[0], cwd, nil
+}
+
+// listForDir returns the claude sessions recorded for a working directory,
+// newest first, capped at maxAdoptableSessions. A missing slug directory means
+// no sessions, not an error.
+func (t claudeTranscripts) listForDir(dir string) ([]entity.ExternalClaudeSession, error) {
+	slugDir := filepath.Join(t.baseDir, projectSlug(dir))
+	entries, err := os.ReadDir(slugDir)
+	if os.IsNotExist(err) {
+		return []entity.ExternalClaudeSession{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read claude project directory: %w", err)
+	}
+
+	sessions := []entity.ExternalClaudeSession{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".jsonl")
+		if _, parseErr := uuid.Parse(id); parseErr != nil {
+			continue
+		}
+		cwd, firstMessage, scanErr := t.scanTranscript(filepath.Join(slugDir, e.Name()))
+		// The slug is lossy, so only transcripts whose recorded cwd matches exactly count.
+		if scanErr != nil || cwd != dir {
+			continue
+		}
+		info, infoErr := e.Info()
+		if infoErr != nil {
+			continue
+		}
+		sessions = append(sessions, entity.ExternalClaudeSession{
+			ID:           id,
+			Cwd:          cwd,
+			FirstMessage: truncateRunes(firstMessage, firstMessageMaxRunes),
+			ModTime:      info.ModTime(),
+			SizeBytes:    info.Size(),
+		})
+	}
+
+	sort.Slice(sessions, func(i, j int) bool { return sessions[i].ModTime.After(sessions[j].ModTime) })
+	if len(sessions) > maxAdoptableSessions {
+		sessions = sessions[:maxAdoptableSessions]
+	}
+	return sessions, nil
+}

--- a/internal/application/service/claude_transcripts_test.go
+++ b/internal/application/service/claude_transcripts_test.go
@@ -1,0 +1,179 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeTranscript(t *testing.T, baseDir string, dir string, name string, lines []string) string {
+	t.Helper()
+	slugDir := filepath.Join(baseDir, projectSlug(dir))
+	if err := os.MkdirAll(slugDir, 0755); err != nil {
+		t.Fatalf("failed to create slug dir: %v", err)
+	}
+	path := filepath.Join(slugDir, name)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatalf("failed to write transcript: %v", err)
+	}
+	return path
+}
+
+func TestProjectSlug(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"/Users/gabriel.herter/Documents/Projects/quant", "-Users-gabriel-herter-Documents-Projects-quant"},
+		{"/tmp/my_project (v2)", "-tmp-my-project--v2-"},
+		{"/home/dev/café", "-home-dev-caf-"},
+		{"C:\\Users\\dev\\repo", "C--Users-dev-repo"},
+	}
+	for _, c := range cases {
+		if got := projectSlug(c.in); got != c.want {
+			t.Errorf("projectSlug(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTranscriptCwd(t *testing.T) {
+	baseDir := t.TempDir()
+	dir := "/tmp/proj"
+
+	// cwd appears on a later line, not line 1.
+	path := writeTranscript(t, baseDir, dir, "a.jsonl", []string{
+		`{"type":"last-prompt","value":"something"}`,
+		`{"type":"user","cwd":"/tmp/proj","message":{"content":"hello there"}}`,
+	})
+
+	ts := claudeTranscripts{baseDir: baseDir}
+	cwd, err := ts.transcriptCwd(path)
+	if err != nil {
+		t.Fatalf("transcriptCwd failed: %v", err)
+	}
+	if cwd != dir {
+		t.Errorf("transcriptCwd = %q, want %q", cwd, dir)
+	}
+
+	// No cwd at all → error.
+	noCwd := writeTranscript(t, baseDir, dir, "b.jsonl", []string{
+		`{"type":"last-prompt","value":"x"}`,
+	})
+	if _, err := ts.transcriptCwd(noCwd); err == nil {
+		t.Error("expected error for transcript without cwd")
+	}
+}
+
+func TestFindByID(t *testing.T) {
+	baseDir := t.TempDir()
+	dir := "/tmp/proj"
+	id := "5b1e9c1a-1234-4abc-9def-0123456789ab"
+
+	writeTranscript(t, baseDir, dir, id+".jsonl", []string{
+		`{"type":"user","cwd":"/tmp/proj","message":{"content":"hi"}}`,
+	})
+
+	ts := claudeTranscripts{baseDir: baseDir}
+	path, cwd, err := ts.findByID(id)
+	if err != nil {
+		t.Fatalf("findByID failed: %v", err)
+	}
+	if cwd != dir {
+		t.Errorf("findByID cwd = %q, want %q", cwd, dir)
+	}
+	if filepath.Base(path) != id+".jsonl" {
+		t.Errorf("findByID path = %q, want file %s.jsonl", path, id)
+	}
+
+	_, _, err = ts.findByID("99999999-9999-4999-9999-999999999999")
+	if err == nil {
+		t.Fatal("expected error for missing transcript")
+	}
+	if !strings.Contains(err.Error(), "no claude session") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestListForDir(t *testing.T) {
+	baseDir := t.TempDir()
+	dir := "/tmp/proj"
+
+	// String content, plus a leading "<command>"-style user message that must be skipped.
+	oldest := writeTranscript(t, baseDir, dir, "11111111-1111-4111-8111-111111111111.jsonl", []string{
+		`{"type":"user","cwd":"/tmp/proj","message":{"content":"<command-name>/clear</command-name>"}}`,
+		`{"type":"user","cwd":"/tmp/proj","message":{"content":"fix the login bug"}}`,
+	})
+
+	// Blocks-array content.
+	newest := writeTranscript(t, baseDir, dir, "22222222-2222-4222-8222-222222222222.jsonl", []string{
+		`{"type":"last-prompt","value":"x"}`,
+		`{"type":"user","cwd":"/tmp/proj","message":{"content":[{"type":"text","text":"add dark mode"}]}}`,
+	})
+
+	// cwd mismatch (slug collision) — must be skipped.
+	writeTranscript(t, baseDir, dir, "33333333-3333-4333-8333-333333333333.jsonl", []string{
+		`{"type":"user","cwd":"/tmp/proj2","message":{"content":"wrong dir"}}`,
+	})
+
+	// Non-UUID filename — must be skipped.
+	writeTranscript(t, baseDir, dir, "notes.jsonl", []string{
+		`{"type":"user","cwd":"/tmp/proj","message":{"content":"not a session"}}`,
+	})
+
+	// Pin mtimes so the ordering assertion is deterministic.
+	now := time.Now()
+	if err := os.Chtimes(oldest, now.Add(-time.Hour), now.Add(-time.Hour)); err != nil {
+		t.Fatalf("failed to set mtime: %v", err)
+	}
+	if err := os.Chtimes(newest, now, now); err != nil {
+		t.Fatalf("failed to set mtime: %v", err)
+	}
+
+	ts := claudeTranscripts{baseDir: baseDir}
+	sessions, err := ts.listForDir(dir)
+	if err != nil {
+		t.Fatalf("listForDir failed: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("listForDir returned %d sessions, want 2", len(sessions))
+	}
+	if sessions[0].ID != "22222222-2222-4222-8222-222222222222" {
+		t.Errorf("expected newest session first, got %s", sessions[0].ID)
+	}
+	if sessions[0].FirstMessage != "add dark mode" {
+		t.Errorf("blocks-array first message = %q, want %q", sessions[0].FirstMessage, "add dark mode")
+	}
+	if sessions[1].FirstMessage != "fix the login bug" {
+		t.Errorf("string first message = %q, want %q", sessions[1].FirstMessage, "fix the login bug")
+	}
+	for _, sess := range sessions {
+		if sess.Cwd != dir {
+			t.Errorf("session %s cwd = %q, want %q", sess.ID, sess.Cwd, dir)
+		}
+		if sess.SizeBytes <= 0 {
+			t.Errorf("session %s has no size", sess.ID)
+		}
+	}
+
+	// Missing slug dir → empty list, not an error.
+	empty, err := ts.listForDir("/nowhere/else")
+	if err != nil {
+		t.Fatalf("listForDir for missing dir failed: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("expected empty list for missing slug dir, got %d", len(empty))
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	long := strings.Repeat("é", 200)
+	got := truncateRunes(long, firstMessageMaxRunes)
+	if len([]rune(got)) != firstMessageMaxRunes {
+		t.Errorf("truncateRunes length = %d runes, want %d", len([]rune(got)), firstMessageMaxRunes)
+	}
+	if truncateRunes("short", firstMessageMaxRunes) != "short" {
+		t.Error("truncateRunes should not change short strings")
+	}
+}

--- a/internal/application/service/session_manager.go
+++ b/internal/application/service/session_manager.go
@@ -30,6 +30,7 @@ type sessionManagerService struct {
 	manageWorktree usecase.ManageWorktree
 	loadConfig     usecase.LoadConfig
 	saveConfig     usecase.SaveConfig
+	transcripts    claudeTranscripts
 }
 
 // NewSessionManagerService creates a new SessionManager service.
@@ -55,6 +56,7 @@ func NewSessionManagerService(
 		manageWorktree: manageWorktree,
 		loadConfig:     loadConfig,
 		saveConfig:     saveConfig,
+		transcripts:    newClaudeTranscripts(),
 	}
 }
 
@@ -88,6 +90,36 @@ func (s *sessionManagerService) CreateSession(name string, description string, s
 			directory = opts.DirectoryOverride
 		}
 	}
+	var claudeConvID string
+	if opts.ClaudeSessionID != "" {
+		if opts.UseWorktree {
+			return nil, fmt.Errorf("cannot use a worktree when adopting an existing claude session")
+		}
+		if _, err := uuid.Parse(opts.ClaudeSessionID); err != nil {
+			return nil, fmt.Errorf("invalid claude session id: %s", opts.ClaudeSessionID)
+		}
+		existing, err := s.findSession.FindAll()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list sessions: %w", err)
+		}
+		for i := range existing {
+			if existing[i].ClaudeConvID == opts.ClaudeSessionID || existing[i].ID == opts.ClaudeSessionID {
+				return nil, fmt.Errorf("claude session %s is already attached to session %s", opts.ClaudeSessionID, existing[i].Name)
+			}
+		}
+		_, cwd, err := s.transcripts.findByID(opts.ClaudeSessionID)
+		if err != nil {
+			return nil, err
+		}
+		if info, statErr := os.Stat(cwd); statErr != nil || !info.IsDir() {
+			return nil, fmt.Errorf("the claude session's working directory %s no longer exists", cwd)
+		}
+		// --resume only finds the transcript when the process cwd matches it,
+		// so the transcript's cwd overrides the repo path.
+		directory = cwd
+		claudeConvID = opts.ClaudeSessionID
+	}
+
 	var worktreePath, branchName string
 
 	if opts.UseWorktree && repoID != "" {
@@ -117,6 +149,7 @@ func (s *sessionManagerService) CreateSession(name string, description string, s
 		Directory:       directory,
 		WorktreePath:    worktreePath,
 		BranchName:      branchName,
+		ClaudeConvID:    claudeConvID,
 		RepoID:          repoID,
 		TaskID:          taskID,
 		SkipPermissions: opts.SkipPermissions,
@@ -581,7 +614,15 @@ func (s *sessionManagerService) UpdateSessionWorkspace(id string, workspaceID st
 	return s.updateSession.Update(*session)
 }
 
-// RenameSession updates the name of a session.
+// renameSubmitKeyDelay is the pause between writing the /rename command to a
+// session's PTY and writing the Enter keystroke that submits it. It gives the
+// Claude CLI TUI time to process the pasted text before the carriage return
+// arrives as a discrete submit rather than a multi-line newline.
+const renameSubmitKeyDelay = 120 * time.Millisecond
+
+// RenameSession updates the name of a session. For a running claude session it
+// also injects claude's /rename slash command into the PTY (best-effort) so the
+// claude CLI's own session title stays in sync.
 func (s *sessionManagerService) RenameSession(id string, newName string) error {
 	session, err := s.findSession.FindByID(id)
 	if err != nil {
@@ -592,7 +633,105 @@ func (s *sessionManagerService) RenameSession(id string, newName string) error {
 	}
 	session.Name = newName
 	session.UpdatedAt = time.Now()
+	if err := s.updateSession.Update(*session); err != nil {
+		return err
+	}
+
+	if session.SessionType != sessiontype.Terminal && session.Status == sessionstatus.Running {
+		go func() {
+			if err := s.spawnProcess.SendMessage(id, "/rename "+newName); err != nil {
+				log.Printf("rename sync: failed to type /rename into session %s: %v", id, err)
+				return
+			}
+			time.Sleep(renameSubmitKeyDelay)
+			if err := s.spawnProcess.SendMessage(id, "\r"); err != nil {
+				log.Printf("rename sync: failed to submit /rename in session %s: %v", id, err)
+			}
+		}()
+	}
+
+	return nil
+}
+
+// SetClaudeSessionID attaches an existing claude CLI conversation to a session,
+// or detaches the current one when claudeID is empty. Detaching clears
+// ClaudeConvID so the next start begins a fresh conversation with
+// --session-id <quant ID>; if claude already consumed that UUID (the session
+// ran before), claude rejects the reused id visibly in the terminal.
+func (s *sessionManagerService) SetClaudeSessionID(sessionID string, claudeID string) error {
+	session, err := s.findSession.FindByID(sessionID)
+	if err != nil {
+		return fmt.Errorf("failed to find session: %w", err)
+	}
+	if session == nil {
+		return fmt.Errorf("session not found: %s", sessionID)
+	}
+	if session.SessionType != sessiontype.Claude {
+		return fmt.Errorf("session %s is not a claude session", session.Name)
+	}
+	if session.Status == sessionstatus.Running {
+		return fmt.Errorf("session %s is running — stop the session first", session.Name)
+	}
+
+	if claudeID != "" {
+		if _, err := uuid.Parse(claudeID); err != nil {
+			return fmt.Errorf("invalid claude session id: %s", claudeID)
+		}
+		all, err := s.findSession.FindAll()
+		if err != nil {
+			return fmt.Errorf("failed to list sessions: %w", err)
+		}
+		for i := range all {
+			if all[i].ID == sessionID {
+				continue
+			}
+			if all[i].ClaudeConvID == claudeID || all[i].ID == claudeID {
+				return fmt.Errorf("claude session %s is already attached to session %s", claudeID, all[i].Name)
+			}
+		}
+		_, cwd, err := s.transcripts.findByID(claudeID)
+		if err != nil {
+			return err
+		}
+		workDir := getWorkDir(session)
+		if cwd != workDir {
+			return fmt.Errorf("claude session %s belongs to directory %s but this session runs in %s — directories must match for --resume to find the conversation", claudeID, cwd, workDir)
+		}
+	}
+
+	session.ClaudeConvID = claudeID
+	session.UpdatedAt = time.Now()
 	return s.updateSession.Update(*session)
+}
+
+// ListAdoptableSessions returns claude CLI sessions recorded for a directory
+// that are not yet attached to any quant session.
+func (s *sessionManagerService) ListAdoptableSessions(directory string) ([]entity.ExternalClaudeSession, error) {
+	candidates, err := s.transcripts.listForDir(directory)
+	if err != nil {
+		return nil, err
+	}
+
+	existing, err := s.findSession.FindAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sessions: %w", err)
+	}
+	used := make(map[string]bool, len(existing)*2)
+	for i := range existing {
+		used[existing[i].ID] = true
+		if existing[i].ClaudeConvID != "" {
+			used[existing[i].ClaudeConvID] = true
+		}
+	}
+
+	adoptable := make([]entity.ExternalClaudeSession, 0, len(candidates))
+	for _, c := range candidates {
+		if used[c.ID] {
+			continue
+		}
+		adoptable = append(adoptable, c)
+	}
+	return adoptable, nil
 }
 
 // CheckBranchExists checks if a git branch already exists in the given repo.

--- a/internal/domain/entity/external_claude_session.go
+++ b/internal/domain/entity/external_claude_session.go
@@ -1,0 +1,15 @@
+package entity
+
+import (
+	"time"
+)
+
+// ExternalClaudeSession represents a claude CLI session found on disk
+// (under ~/.claude/projects) that is not yet attached to a quant session.
+type ExternalClaudeSession struct {
+	ID           string
+	Cwd          string
+	FirstMessage string
+	ModTime      time.Time
+	SizeBytes    int64
+}

--- a/internal/domain/entity/session_options.go
+++ b/internal/domain/entity/session_options.go
@@ -14,4 +14,5 @@ type SessionOptions struct {
 	DirectoryOverride string // If set, use this directory instead of repo path
 	WorkspaceID       string // Workspace to assign the session to
 	NoFlicker         bool   // Enable NO_FLICKER terminal mode
+	ClaudeSessionID   string // If set, adopt this existing claude CLI session (resume its conversation)
 }

--- a/internal/integration/adapter/session_controller.go
+++ b/internal/integration/adapter/session_controller.go
@@ -29,6 +29,8 @@ type SessionController interface {
 	GetSessionOutput(id string) (string, error)
 	MoveSessionToTask(sessionID string, newTaskID string) error
 	RenameSession(id string, newName string) error
+	SetClaudeSessionID(sessionID string, claudeID string) error
+	ListAdoptableSessions(directory string) ([]dto.ExternalSessionResponse, error)
 	CheckBranchExists(repoID string, branchName string) (bool, error)
 	RunShortcut(sessionID string, command string) error
 	GitCommit(sessionID string, message string) error

--- a/internal/integration/entrypoint/controller/session.go
+++ b/internal/integration/entrypoint/controller/session.go
@@ -57,6 +57,7 @@ func (c *sessionController) CreateSession(request dto.CreateSessionRequest) (*dt
 		DirectoryOverride: request.DirectoryOverride,
 		WorkspaceID:       request.WorkspaceID,
 		NoFlicker:         true, // Regular sessions always use NO_FLICKER
+		ClaudeSessionID:   request.ClaudeSessionID,
 	}
 	session, err := c.sessionManager.CreateSession(request.Name, request.Description, request.SessionType, request.RepoID, request.TaskID, opts)
 	if err != nil {
@@ -163,6 +164,23 @@ func (c *sessionController) MoveSessionToTask(sessionID string, newTaskID string
 // RenameSession updates the name of a session.
 func (c *sessionController) RenameSession(id string, newName string) error {
 	return c.sessionManager.RenameSession(id, newName)
+}
+
+// SetClaudeSessionID attaches an existing claude CLI conversation to a session,
+// or detaches the current one when claudeID is empty.
+func (c *sessionController) SetClaudeSessionID(sessionID string, claudeID string) error {
+	return c.sessionManager.SetClaudeSessionID(sessionID, claudeID)
+}
+
+// ListAdoptableSessions returns claude CLI sessions found on disk for a directory
+// that are not yet attached to any quant session.
+func (c *sessionController) ListAdoptableSessions(directory string) ([]dto.ExternalSessionResponse, error) {
+	sessions, err := c.sessionManager.ListAdoptableSessions(directory)
+	if err != nil {
+		return nil, err
+	}
+
+	return dto.ExternalSessionResponseListFromEntities(sessions), nil
 }
 
 // CheckBranchExists checks if a git branch already exists in the given repo.

--- a/internal/integration/entrypoint/dto/session.go
+++ b/internal/integration/entrypoint/dto/session.go
@@ -23,6 +23,37 @@ type CreateSessionRequest struct {
 	ExtraCliArgs      string `json:"extraCliArgs"`
 	DirectoryOverride string `json:"directoryOverride"`
 	WorkspaceID       string `json:"workspaceId"`
+	ClaudeSessionID   string `json:"claudeSessionId"`
+}
+
+// ExternalSessionResponse represents a claude CLI session found on disk that
+// can be adopted into quant.
+type ExternalSessionResponse struct {
+	ID           string `json:"id"`
+	Cwd          string `json:"cwd"`
+	FirstMessage string `json:"firstMessage"`
+	ModTime      string `json:"modTime"`
+	SizeBytes    int64  `json:"sizeBytes"`
+}
+
+// ExternalSessionResponseFromEntity converts a domain entity to an ExternalSessionResponse DTO.
+func ExternalSessionResponseFromEntity(session entity.ExternalClaudeSession) ExternalSessionResponse {
+	return ExternalSessionResponse{
+		ID:           session.ID,
+		Cwd:          session.Cwd,
+		FirstMessage: session.FirstMessage,
+		ModTime:      session.ModTime.Format("2006-01-02T15:04:05Z07:00"),
+		SizeBytes:    session.SizeBytes,
+	}
+}
+
+// ExternalSessionResponseListFromEntities converts a slice of domain entities to a slice of ExternalSessionResponse DTOs.
+func ExternalSessionResponseListFromEntities(sessions []entity.ExternalClaudeSession) []ExternalSessionResponse {
+	responses := make([]ExternalSessionResponse, len(sessions))
+	for i, session := range sessions {
+		responses[i] = ExternalSessionResponseFromEntity(session)
+	}
+	return responses
 }
 
 // SessionResponse represents the response payload for session data.

--- a/internal/integration/mcp/server.go
+++ b/internal/integration/mcp/server.go
@@ -674,6 +674,7 @@ Returns the created session object with generated ID. The session starts in 'idl
 			mcp.WithBoolean("useWorktree", mcp.Description("Create a git worktree for this session. Default: false")),
 			mcp.WithBoolean("skipPermissions", mcp.Description("Skip permission prompts (--dangerously-skip-permissions). Default: false")),
 			mcp.WithString("model", mcp.Description("Claude model for claude sessions (e.g. 'claude-sonnet-4-6')")),
+			mcp.WithString("claudeSessionId", mcp.Description("Adopt an existing claude CLI session: its UUID from another terminal. The session will resume that conversation; incompatible with useWorktree.")),
 		),
 		s.handleCreateSession,
 	)
@@ -746,6 +747,24 @@ Returns the created session object with generated ID. The session starts in 'idl
 			mcp.WithString("newName", mcp.Required(), mcp.Description("New name for the session")),
 		),
 		s.handleRenameSession,
+	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("set_session_claude_id",
+			mcp.WithDescription(`Attach an existing claude CLI conversation to a session, or detach the current one. The session must be a claude session and must not be running. The claude session's working directory must match the session's working directory for --resume to find the conversation.`),
+			mcp.WithString("sessionId", mcp.Required(), mcp.Description("Session ID (get from list_sessions)")),
+			mcp.WithString("claudeSessionId", mcp.Description("Claude CLI session UUID to attach. Empty string detaches so the next start begins a fresh conversation.")),
+		),
+		s.handleSetSessionClaudeID,
+	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("list_adoptable_sessions",
+			mcp.WithDescription(`List claude CLI sessions found on this machine for a working directory that are not yet attached to any quant session. Provide either directory or repoId. Returns id, cwd, firstMessage, modTime, and sizeBytes for each adoptable session.`),
+			mcp.WithString("directory", mcp.Description("Absolute path of the working directory to scan")),
+			mcp.WithString("repoId", mcp.Description("Repository ID whose path is used as the directory (get from list_repos)")),
+		),
+		s.handleListAdoptableSessions,
 	)
 
 	// -----------------------------------------------------------------------
@@ -2208,6 +2227,7 @@ func (s *QuantMCPServer) handleCreateSession(_ context.Context, request mcp.Call
 		Model:           stringArg(args, "model"),
 		WorkspaceID:     stringArg(args, "workspaceId"),
 		NoFlicker:       true,
+		ClaudeSessionID: stringArg(args, "claudeSessionId"),
 	}
 
 	session, err := s.sessionManager.CreateSession(name, description, sessionType, repoID, taskID, opts)
@@ -2357,6 +2377,60 @@ func (s *QuantMCPServer) handleRenameSession(_ context.Context, request mcp.Call
 	}
 
 	return mcp.NewToolResultText(fmt.Sprintf("Session %s renamed to '%s'", id, newName)), nil
+}
+
+func (s *QuantMCPServer) handleSetSessionClaudeID(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	sessionID, err := requiredString(request, "sessionId")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	claudeID := stringArg(request.GetArguments(), "claudeSessionId")
+
+	if err := s.sessionManager.SetClaudeSessionID(sessionID, claudeID); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	if claudeID == "" {
+		return mcp.NewToolResultText(fmt.Sprintf("Session %s detached from its claude conversation — the next start begins fresh", sessionID)), nil
+	}
+	return mcp.NewToolResultText(fmt.Sprintf("Session %s attached to claude session %s", sessionID, claudeID)), nil
+}
+
+func (s *QuantMCPServer) handleListAdoptableSessions(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+	directory := stringArg(args, "directory")
+	repoID := stringArg(args, "repoId")
+
+	if directory == "" && repoID == "" {
+		return mcp.NewToolResultError("either directory or repoId is required"), nil
+	}
+	if directory == "" {
+		repo, err := s.repoManager.GetRepo(repoID)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		directory = repo.Path
+	}
+
+	sessions, err := s.sessionManager.ListAdoptableSessions(directory)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	result := make([]map[string]any, 0, len(sessions))
+	for i := range sessions {
+		sess := &sessions[i]
+		result = append(result, map[string]any{
+			"id":           sess.ID,
+			"cwd":          sess.Cwd,
+			"firstMessage": sess.FirstMessage,
+			"modTime":      sess.ModTime.Format(time.RFC3339),
+			"sizeBytes":    sess.SizeBytes,
+		})
+	}
+
+	return marshalResult(result)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Quant can now attach to claude CLI conversations that were created outside quant (e.g. in a plain terminal), and renaming a quant session keeps claude's own session title in sync.

### Adopt external sessions
- **New session → "resume an existing session"**: lists the untracked claude conversations found in `~/.claude/projects` for the chosen repo's directory (short id, first-message snippet, age), plus a paste-a-UUID input. Adopting pre-fills `ClaudeConvID`, so the first start runs `claude --resume <uuid>` instead of creating a fresh conversation.
- The session's directory is pinned to the transcript's own `cwd` (read from the jsonl — required for `--resume` to find the conversation) and worktrees are rejected while adopting.
- **Context menu → "change claude session id"** on stopped sessions: attach a different conversation (validated: UUID format, transcript exists, directory matches) or **detach** so the next start begins fresh.
- **MCP**: `create_session` accepts `claudeSessionId`; new `list_adoptable_sessions` (by `directory` or `repoId`) and `set_session_claude_id` tools, so orchestrator sessions can adopt terminal-born sessions.

### Rename sync
- `RenameSession` (UI + `rename_session` MCP) now also injects `/rename <new name>` into a *running* claude session's PTY (Enter sent as a separate keystroke after 120ms, same mechanism as `send_message`), best-effort. Claude persists the title (`custom-title` in the transcript), so it survives resumes.

## E2E (sandboxed instance, real claude processes)
- Adopted a real 4-day-old terminal-born session via the UI: spawn showed `--resume <uuid>`, terminal rendered the prior conversation history.
- Detach/re-attach round-trip via the change-id modal; MCP list/create/set tools verified.
- Probes: worktree+adopt rejected; unknown UUID → "no claude session … found on this machine"; running session → "stop the session first"; UUID from another project dir → error naming both directories; invalid UUID disables submit.
- Rename of a running session: TUI executed `/rename` with inline arg, confirmation rendered, `custom-title` written to the transcript; stopped-session rename unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)